### PR TITLE
Only use Path.Combine on netcore

### DIFF
--- a/Library/DiscUtils.Core/Internal/Utilities.cs
+++ b/Library/DiscUtils.Core/Internal/Utilities.cs
@@ -207,7 +207,7 @@ public static class Utilities
     /// <returns>The combined path.</returns>
     public static string CombinePaths(string a, string b)
     {
-#if NETSTANDARD || NETCOREAPP
+#if NETCOREAPP
         return Path.Combine(a, b);
 #else
         if (string.IsNullOrEmpty(a) || (b.Length > 0 && b[0] == '\\'))

--- a/Library/DiscUtils.Core/Internal/Utilities.cs
+++ b/Library/DiscUtils.Core/Internal/Utilities.cs
@@ -207,7 +207,7 @@ public static class Utilities
     /// <returns>The combined path.</returns>
     public static string CombinePaths(string a, string b)
     {
-#if NET461_OR_GREATER || NETSTANDARD || NETCOREAPP
+#if NETSTANDARD || NETCOREAPP
         return Path.Combine(a, b);
 #else
         if (string.IsNullOrEmpty(a) || (b.Length > 0 && b[0] == '\\'))


### PR DESCRIPTION
Path.Combine has more restrictive (windows specific) behavior on Net Framework which can present problems with extracting files from formats like .dmg.

For example, this attached dmg (created from a folder with two text files using `hdiutil` on Mac OS, GitHub doesn't allow dmgs to be directly attached so I have zipped it) causes an Argument Exception on net4.8 but not net6 - net8 with the current code, this change resolves that argument exception allowing the dmg to also be extracted by net4.8 based programs using DiscUtils.

[HfsSampleUDCO.zip](https://github.com/LTRData/DiscUtils/files/14069422/HfsSampleUDCO.zip)

See also: https://github.com/microsoft/RecursiveExtractor/pull/145
