### PR TITLE
Encoding, Cleanup

### DIFF
--- a/Library/DiscUtils.Core/ApplePartitionMap/PartitionMapEntry.cs
+++ b/Library/DiscUtils.Core/ApplePartitionMap/PartitionMapEntry.cs
@@ -84,12 +84,14 @@ internal sealed class PartitionMapEntry : PartitionInfo, IByteArraySerializable
 
     public int ReadFrom(ReadOnlySpan<byte> buffer)
     {
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
         Signature = EndianUtilities.ToUInt16BigEndian(buffer);
         MapEntries = EndianUtilities.ToUInt32BigEndian(buffer.Slice(4));
         PhysicalBlockStart = EndianUtilities.ToUInt32BigEndian(buffer.Slice(8));
         PhysicalBlocks = EndianUtilities.ToUInt32BigEndian(buffer.Slice(12));
-        Name = EndianUtilities.BytesToString(buffer.Slice(16, 32)).TrimEnd('\0');
-        Type = EndianUtilities.BytesToString(buffer.Slice(48, 32)).TrimEnd('\0');
+        Name = latin1Encoding.GetString(buffer.Slice(16, 32)).TrimEnd('\0');
+        Type = latin1Encoding.GetString(buffer.Slice(48, 32)).TrimEnd('\0');
         LogicalBlockStart = EndianUtilities.ToUInt32BigEndian(buffer.Slice(80));
         LogicalBlocks = EndianUtilities.ToUInt32BigEndian(buffer.Slice(84));
         Flags = EndianUtilities.ToUInt32BigEndian(buffer.Slice(88));

--- a/Library/DiscUtils.Core/Archives/TarFile.cs
+++ b/Library/DiscUtils.Core/Archives/TarFile.cs
@@ -20,14 +20,14 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-namespace DiscUtils.Archives;
-
 using LTRData.Extensions.Buffers;
-using Streams;
+using DiscUtils.Streams;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
+
+namespace DiscUtils.Archives;
 
 /// <summary>
 /// Minimal tar file format implementation.
@@ -75,7 +75,11 @@ public class TarFile : IDisposable
                 try
                 {
                     _fileStream.ReadExactly(buffer, 0, (int)hdr.FileLength);
-                    long_path = EndianUtilities.BytesToString(TarHeader.ReadNullTerminatedString(buffer.AsSpan(0, (int)hdr.FileLength)));
+
+                    long_path = EncodingUtilities
+                        .GetLatin1Encoding()
+                        .GetString(TarHeader.ReadNullTerminatedString(buffer.AsSpan(0, (int)hdr.FileLength)));
+
                     _fileStream.Position += -(buffer.Length & 511) & 511;
                 }
                 finally
@@ -225,7 +229,9 @@ public class TarFile : IDisposable
                 {
                     archive.ReadExactly(data, 0, (int)hdr.FileLength);
 
-                    long_path = EndianUtilities.BytesToString(TarHeader.ReadNullTerminatedString(data.AsSpan(0, (int)hdr.FileLength)));
+                    long_path = EncodingUtilities
+                        .GetLatin1Encoding()
+                        .GetString(TarHeader.ReadNullTerminatedString(data.AsSpan(0, (int)hdr.FileLength)));
                 }
                 finally
                 {

--- a/Library/DiscUtils.Core/LogicalDiskManager/DatabaseHeader.cs
+++ b/Library/DiscUtils.Core/LogicalDiskManager/DatabaseHeader.cs
@@ -53,15 +53,17 @@ internal class DatabaseHeader
 
     public void ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Signature = EndianUtilities.BytesToString(buffer.Slice(0x00, 4));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        Signature = latin1Encoding.GetString(buffer.Slice(0x00, 4));
         NumVBlks = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x04));
         BlockSize = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x08));
         HeaderSize = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x0C));
         Unknown1 = EndianUtilities.ToUInt16BigEndian(buffer.Slice(0x10));
         VersionNum = EndianUtilities.ToUInt16BigEndian(buffer.Slice(0x12));
         VersionDenom = EndianUtilities.ToUInt16BigEndian(buffer.Slice(0x14));
-        GroupName = EndianUtilities.BytesToString(buffer.Slice(0x16, 31)).Trim('\0');
-        DiskGroupId = EndianUtilities.BytesToString(buffer.Slice(0x35, 0x40)).Trim('\0');
+        GroupName = latin1Encoding.GetString(buffer.Slice(0x16, 31)).Trim('\0');
+        DiskGroupId = latin1Encoding.GetString(buffer.Slice(0x35, 0x40)).Trim('\0');
 
         // May be wrong way round...
         CommittedSequence = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x75));

--- a/Library/DiscUtils.Core/LogicalDiskManager/DatabaseRecord.cs
+++ b/Library/DiscUtils.Core/LogicalDiskManager/DatabaseRecord.cs
@@ -85,7 +85,10 @@ internal abstract class DatabaseRecord
     {
         int length = buffer[offset];
 
-        var result = EndianUtilities.BytesToString(buffer, offset + 1, length);
+        var result = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(buffer, offset + 1, length);
+
         offset += length + 1;
         return result;
     }
@@ -116,7 +119,10 @@ internal abstract class DatabaseRecord
     protected static string ReadString(byte[] buffer, int len, ref int offset)
     {
         offset += len;
-        return EndianUtilities.BytesToString(buffer, offset - len, len);
+
+        return EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(buffer, offset - len, len);
     }
 
     protected static Guid ReadBinaryGuid(byte[] buffer, ref int offset)
@@ -129,7 +135,9 @@ internal abstract class DatabaseRecord
 
     protected virtual void DoReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Signature = EndianUtilities.BytesToString(buffer.Slice(0x00, 4));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        Signature = latin1Encoding.GetString(buffer.Slice(0x00, 4));
         Label = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x04));
         Counter = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x08));
         Valid = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x0C));

--- a/Library/DiscUtils.Core/LogicalDiskManager/PrivateHeader.cs
+++ b/Library/DiscUtils.Core/LogicalDiskManager/PrivateHeader.cs
@@ -52,17 +52,19 @@ internal class PrivateHeader
 
     public void ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Signature = EndianUtilities.BytesToString(buffer.Slice(0x00, 8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        Signature = latin1Encoding.GetString(buffer.Slice(0x00, 8));
         Checksum = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x08));
         Version = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x0C));
         Timestamp = DateTime.FromFileTimeUtc(EndianUtilities.ToInt64BigEndian(buffer.Slice(0x10)));
         Unknown2 = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x18));
         Unknown3 = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x20));
         Unknown4 = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x28));
-        DiskId = EndianUtilities.BytesToString(buffer.Slice(0x30, 0x40)).Trim('\0');
-        HostId = EndianUtilities.BytesToString(buffer.Slice(0x70, 0x40)).Trim('\0');
-        DiskGroupId = EndianUtilities.BytesToString(buffer.Slice(0xB0, 0x40)).Trim('\0');
-        DiskGroupName = EndianUtilities.BytesToString(buffer.Slice(0xF0, 31)).Trim('\0');
+        DiskId = latin1Encoding.GetString(buffer.Slice(0x30, 0x40)).Trim('\0');
+        HostId = latin1Encoding.GetString(buffer.Slice(0x70, 0x40)).Trim('\0');
+        DiskGroupId = latin1Encoding.GetString(buffer.Slice(0xB0, 0x40)).Trim('\0');
+        DiskGroupName = latin1Encoding.GetString(buffer.Slice(0xF0, 31)).Trim('\0');
         Unknown5 = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x10F));
         DataStartLba = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x11B));
         DataSizeLba = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x123));

--- a/Library/DiscUtils.Core/LogicalDiskManager/TocBlock.cs
+++ b/Library/DiscUtils.Core/LogicalDiskManager/TocBlock.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
 
 namespace DiscUtils.LogicalDiskManager;
 
@@ -45,17 +45,19 @@ internal class TocBlock
 
     public void ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Signature = EndianUtilities.BytesToString(buffer.Slice(0x00, 8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        Signature = latin1Encoding.GetString(buffer.Slice(0x00, 8));
         Checksum = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x08));
         SequenceNumber = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x0C));
         Unknown1 = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x14));
         Unknown2 = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x1C));
-        Item1Str = EndianUtilities.BytesToString(buffer.Slice(0x24, 10)).Trim('\0');
+        Item1Str = latin1Encoding.GetString(buffer.Slice(0x24, 10)).Trim('\0');
         Item1Start = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x2E));
         Item1Size = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x36));
         Unknown3 = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x3E));
         Unknown4 = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x42));
-        Item2Str = EndianUtilities.BytesToString(buffer.Slice(0x46, 10)).Trim('\0');
+        Item2Str = latin1Encoding.GetString(buffer.Slice(0x46, 10)).Trim('\0');
         Item2Start = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x50));
         Item2Size = EndianUtilities.ToInt64BigEndian(buffer.Slice(0x58));
         Unknown5 = EndianUtilities.ToUInt32BigEndian(buffer.Slice(0x60));

--- a/Library/DiscUtils.Core/Partitions/GptHeader.cs
+++ b/Library/DiscUtils.Core/Partitions/GptHeader.cs
@@ -77,7 +77,9 @@ internal class GptHeader
 
     public bool ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Signature = EndianUtilities.BytesToString(buffer.Slice(0, 8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        Signature = latin1Encoding.GetString(buffer.Slice(0, 8));
         Version = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(8));
         HeaderSize = EndianUtilities.ToInt32LittleEndian(buffer.Slice(12));
         Crc = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(16));
@@ -111,7 +113,10 @@ internal class GptHeader
         Buffer.CopyTo(buffer);
 
         // Next, write the fields
-        EndianUtilities.StringToBytes(Signature, buffer.Slice(0, 8));
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes(Signature, buffer.Slice(0, 8));
+
         EndianUtilities.WriteBytesLittleEndian(Version, buffer.Slice(8));
         EndianUtilities.WriteBytesLittleEndian(HeaderSize, buffer.Slice(12));
         EndianUtilities.WriteBytesLittleEndian((uint)0, buffer.Slice(16));

--- a/Library/DiscUtils.Fat/FatFileSystem.cs
+++ b/Library/DiscUtils.Fat/FatFileSystem.cs
@@ -1498,7 +1498,9 @@ public sealed class FatFileSystem : DiscFileSystem, IDosFileSystem, IClusterBase
         bootSector[2] = 0x90;
 
         // OEM Name
-        EndianUtilities.StringToBytes("DISCUTIL", bootSector.Slice(3, 8));
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes("DISCUTIL", bootSector.Slice(3, 8));
 
         // Bytes Per Sector (512)
         bootSector[11] = 0;
@@ -1610,11 +1612,13 @@ public sealed class FatFileSystem : DiscFileSystem, IDosFileSystem, IClusterBase
         // Volume Id
         EndianUtilities.WriteBytesLittleEndian(volId, bootSector.Slice(3));
 
+        var encoding = EncodingUtilities.GetLatin1Encoding();
+
         // Volume Label
-        EndianUtilities.StringToBytes(label.PadRight(11, ' ').AsSpan(0, 11), bootSector.Slice(7, 11));
+        encoding.GetBytes(label.PadRight(11, ' ').AsSpan(0, 11), bootSector.Slice(7, 11));
 
         // File System Type
-        EndianUtilities.StringToBytes(fsType, bootSector.Slice(18, 8));
+        encoding.GetBytes(fsType, bootSector.Slice(18, 8));
     }
 
     private static FatType DetectFATType(byte[] bpb)
@@ -1927,7 +1931,7 @@ public sealed class FatFileSystem : DiscFileSystem, IDosFileSystem, IClusterBase
         }
         else
         {
-            throw new ArgumentException("Unrecognised Floppy Disk type", nameof(type));
+            throw new ArgumentException("Unrecognized Floppy Disk type", nameof(type));
         }
 
         stream.Write(bpb);

--- a/Library/DiscUtils.Fat/FileName.cs
+++ b/Library/DiscUtils.Fat/FileName.cs
@@ -25,6 +25,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
 using DiscUtils.Internal;
+using DiscUtils.Streams;
 using DiscUtils.Streams.Compatibility;
 
 namespace DiscUtils.Fat;
@@ -105,7 +106,7 @@ internal sealed class FileName : IEquatable<FileName>
 
         Span<byte> bytes = stackalloc byte[encoding.GetByteCount(name)];
         
-        encoding.GetBytes(name.AsSpan(), bytes);
+        encoding.GetBytes(name, bytes);
 
         if (bytes.Length == 0)
         {

--- a/Library/DiscUtils.Iscsi/ScsiInquiryStandardResponse.cs
+++ b/Library/DiscUtils.Iscsi/ScsiInquiryStandardResponse.cs
@@ -58,12 +58,13 @@ internal class ScsiInquiryStandardResponse : ScsiResponse
             return;
         }
 
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
         DeviceType = (LunClass)(buffer[0] & 0x1F);
         Removable = (buffer[1] & 0x80) != 0;
         SpecificationVersion = buffer[2];
-
-        VendorId = EndianUtilities.BytesToString(buffer, 8, 8);
-        ProductId = EndianUtilities.BytesToString(buffer, 16, 16);
-        ProductRevision = EndianUtilities.BytesToString(buffer, 32, 4);
+        VendorId = latin1Encoding.GetString(buffer, 8, 8);
+        ProductId = latin1Encoding.GetString(buffer, 16, 16);
+        ProductRevision = latin1Encoding.GetString(buffer, 32, 4);
     }
 }

--- a/Library/DiscUtils.Iso9660/BaseVolumeDescriptor.cs
+++ b/Library/DiscUtils.Iso9660/BaseVolumeDescriptor.cs
@@ -20,9 +20,9 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams.Compatibility;
 using System;
 using System.Text;
+using DiscUtils.Streams;
 
 namespace DiscUtils.Iso9660;
 

--- a/Library/DiscUtils.Iso9660/BootValidationEntry.cs
+++ b/Library/DiscUtils.Iso9660/BootValidationEntry.cs
@@ -46,7 +46,9 @@ internal class BootValidationEntry
 
         HeaderId = _data[0];
         PlatformId = _data[1];
-        ManfId = EndianUtilities.BytesToString(_data, 4, 24).AsSpan().TrimEnd('\0').TrimEnd(' ').ToString();
+        ManfId = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(_data, 4, 24).AsSpan().TrimEnd('\0').TrimEnd(' ').ToString();
     }
 
     public bool ChecksumValid
@@ -68,7 +70,11 @@ internal class BootValidationEntry
         Array.Clear(buffer, offset, 0x20);
         buffer[offset + 0x00] = HeaderId;
         buffer[offset + 0x01] = PlatformId;
-        EndianUtilities.StringToBytes(ManfId, buffer, offset + 0x04, 24);
+
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes(ManfId, 0, ManfId.Length, buffer, offset + 4);
+
         buffer[offset + 0x1E] = 0x55;
         buffer[offset + 0x1F] = 0xAA;
         EndianUtilities.WriteBytesLittleEndian(CalcChecksum(buffer, offset), buffer, offset + 0x1C);

--- a/Library/DiscUtils.Iso9660/BootVolumeDescriptor.cs
+++ b/Library/DiscUtils.Iso9660/BootVolumeDescriptor.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
 
 namespace DiscUtils.Iso9660;
 
@@ -50,7 +50,10 @@ internal class BootVolumeDescriptor : BaseVolumeDescriptor
     {
         base.WriteTo(buffer);
 
-        EndianUtilities.StringToBytes(ElToritoSystemIdentifier, buffer.Slice(7, 0x20));
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes(ElToritoSystemIdentifier, buffer.Slice(7, 0x20));
+
         EndianUtilities.WriteBytesLittleEndian(CatalogSector, buffer.Slice(0x47));
     }
 }

--- a/Library/DiscUtils.Iso9660/IsoUtilities.cs
+++ b/Library/DiscUtils.Iso9660/IsoUtilities.cs
@@ -360,7 +360,9 @@ internal static class IsoUtilities
             return DateTime.MinValue;
         }
 
-        var strForm = EndianUtilities.BytesToString(data.Slice(0, 16));
+        var strForm = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(data.Slice(0, 16));
 
         // Work around bugs in burning software that may use zero bytes (rather than '0' characters)
         strForm = strForm.Replace('\0', '0');
@@ -398,7 +400,11 @@ internal static class IsoUtilities
         }
 
         var strForm = dateTime.ToString("yyyyMMddHHmmssff", CultureInfo.InvariantCulture);
-        EndianUtilities.StringToBytes(strForm, buffer.Slice(0, 16));
+
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes(strForm, buffer.Slice(0, 16));
+        
         buffer[16] = 0;
     }
 

--- a/Library/DiscUtils.Iso9660/RockRidge/PosixNameSystemUseEntry.cs
+++ b/Library/DiscUtils.Iso9660/RockRidge/PosixNameSystemUseEntry.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
 
 namespace DiscUtils.Iso9660;
 
@@ -35,6 +35,8 @@ internal sealed class PosixNameSystemUseEntry : SystemUseEntry
         CheckAndSetCommonProperties(name, length, version, 5, 1);
 
         Flags = data[4];
-        NameData = EndianUtilities.BytesToString(data.Slice(5, length - 5));
+        NameData = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(data.Slice(5, length - 5));
     }
 }

--- a/Library/DiscUtils.Iso9660/Susp/SystemUseEntry.cs
+++ b/Library/DiscUtils.Iso9660/Susp/SystemUseEntry.cs
@@ -44,7 +44,10 @@ internal abstract class SystemUseEntry
             return null;
         }
 
-        var name = EndianUtilities.BytesToString(data.Slice(0, 2));
+        var name = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(data.Slice(0, 2));
+
         length = data[2];
         var version = data[3];
 

--- a/Library/DiscUtils.Lvm/MetadataLogicalVolumeSection.cs
+++ b/Library/DiscUtils.Lvm/MetadataLogicalVolumeSection.cs
@@ -20,15 +20,15 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-namespace DiscUtils.Lvm;
-
 using System;
 using System.IO;
 using System.Collections.Generic;
-using DiscUtils.Streams;
 using System.Linq;
 using System.Runtime.InteropServices;
+using DiscUtils.Streams;
 using LTRData.Extensions.Buffers;
+
+namespace DiscUtils.Lvm;
 
 internal class MetadataLogicalVolumeSection
 {
@@ -43,12 +43,12 @@ internal class MetadataLogicalVolumeSection
     public List<MetadataSegmentSection> Segments;
     private Dictionary<string, PhysicalVolume> _pvs;
     private ulong _extentSize;
+
     internal void Parse(string head, TextReader data)
     {
         var segments = new List<MetadataSegmentSection>();
         Name = head.AsSpan().Trim().TrimEnd('{').TrimEnd().ToString();
         string line;
-        Span<byte> guid = stackalloc byte[16];
         
         while ((line = Metadata.ReadLine(data)) != null)
         {
@@ -60,7 +60,13 @@ internal class MetadataLogicalVolumeSection
                 {
                     case "id":
                         Id = Metadata.ParseStringValue(parameter.Value.Span);
-                        EndianUtilities.StringToBytes(Id.Replace("-", String.Empty), guid);
+
+                        Span<byte> guid = stackalloc byte[16];
+
+                        EncodingUtilities
+                            .GetLatin1Encoding()
+                            .GetBytes(Id.Replace("-", String.Empty).AsSpan(0, 16), guid);
+
                         // Mark it as a version 4 GUID
                         guid[7] = (byte)((guid[7] | 0x40) & 0x4f);
                         guid[8] = (byte)((guid[8] | 0x80) & 0xbf);

--- a/Library/DiscUtils.Lvm/PhysicalVolume.cs
+++ b/Library/DiscUtils.Lvm/PhysicalVolume.cs
@@ -24,10 +24,8 @@ namespace DiscUtils.Lvm;
 
 using System;
 using System.IO;
-using System.Linq;
 using DiscUtils.Partitions;
 using DiscUtils.Streams;
-using DiscUtils.Streams.Compatibility;
 
 internal class PhysicalVolume
 {
@@ -94,7 +92,10 @@ internal class PhysicalVolume
                 return false;
             }
 
-            var label = EndianUtilities.BytesToString(buffer, 0x0, 0x8);
+            var label = EncodingUtilities
+                .GetLatin1Encoding()
+                .GetString(buffer, 0x0, 0x8);
+
             if (label == PhysicalVolumeLabel.LABEL_ID)
             {
                 pvLabel = new PhysicalVolumeLabel();

--- a/Library/DiscUtils.Lvm/PhysicalVolumeLabel.cs
+++ b/Library/DiscUtils.Lvm/PhysicalVolumeLabel.cs
@@ -20,10 +20,10 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-namespace DiscUtils.Lvm;
-
 using DiscUtils.Streams;
 using System;
+
+namespace DiscUtils.Lvm;
 
 internal class PhysicalVolumeLabel : IByteArraySerializable
 {
@@ -43,12 +43,15 @@ internal class PhysicalVolumeLabel : IByteArraySerializable
     /// <inheritdoc />
     public int ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Label = EndianUtilities.BytesToString(buffer.Slice(0, 0x8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        Label = latin1Encoding.GetString(buffer.Slice(0, 0x8));
         Sector = EndianUtilities.ToUInt64LittleEndian(buffer.Slice(0x8));
         Crc = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x10));
         CalculatedCrc = PhysicalVolume.CalcCrc(buffer.Slice(0x14, PhysicalVolume.SECTOR_SIZE - 0x14));
         Offset = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x14));
-        Label2 = EndianUtilities.BytesToString(buffer.Slice(0x18, 0x8));
+        Label2 = latin1Encoding.GetString(buffer.Slice(0x18, 0x8));
+
         return Size;
     }
 

--- a/Library/DiscUtils.Lvm/PvHeader.cs
+++ b/Library/DiscUtils.Lvm/PvHeader.cs
@@ -20,12 +20,12 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-namespace DiscUtils.Lvm;
-
 using DiscUtils.Streams;
 using System;
 using System.Collections.Generic;
 using System.Text;
+
+namespace DiscUtils.Lvm;
 
 internal class PvHeader : IByteArraySerializable
 {
@@ -71,15 +71,16 @@ internal class PvHeader : IByteArraySerializable
 
     private static string ReadUuid(ReadOnlySpan<byte> buffer)
     {
-        var sb = new StringBuilder()
-        .Append(EndianUtilities.BytesToString(buffer.Slice(0, 0x6))).Append('-')
-        .Append(EndianUtilities.BytesToString(buffer.Slice(0x6, 0x4))).Append('-')
-        .Append(EndianUtilities.BytesToString(buffer.Slice(0xA, 0x4))).Append('-')
-        .Append(EndianUtilities.BytesToString(buffer.Slice(0xE, 0x4))).Append('-')
-        .Append(EndianUtilities.BytesToString(buffer.Slice(0x12, 0x4))).Append('-')
-        .Append(EndianUtilities.BytesToString(buffer.Slice(0x16, 0x4))).Append('-')
-        .Append(EndianUtilities.BytesToString(buffer.Slice(0x1A, 0x6)));
-        
-        return sb.ToString();
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        return new StringBuilder()
+            .Append(latin1Encoding.GetString(buffer.Slice(0, 0x6))).Append('-')
+            .Append(latin1Encoding.GetString(buffer.Slice(0x6, 0x4))).Append('-')
+            .Append(latin1Encoding.GetString(buffer.Slice(0xA, 0x4))).Append('-')
+            .Append(latin1Encoding.GetString(buffer.Slice(0xE, 0x4))).Append('-')
+            .Append(latin1Encoding.GetString(buffer.Slice(0x12, 0x4))).Append('-')
+            .Append(latin1Encoding.GetString(buffer.Slice(0x16, 0x4))).Append('-')
+            .Append(latin1Encoding.GetString(buffer.Slice(0x1A, 0x6)))
+            .ToString();
     }
 }

--- a/Library/DiscUtils.Ntfs/BiosParameterBlock.cs
+++ b/Library/DiscUtils.Ntfs/BiosParameterBlock.cs
@@ -22,9 +22,10 @@
 
 using System;
 using System.Buffers;
-using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Runtime.InteropServices;
+
 using System.Security.Cryptography;
 using DiscUtils.Streams;
 using DiscUtils.Streams.Compatibility;
@@ -132,9 +133,11 @@ internal class BiosParameterBlock
 
     internal static BiosParameterBlock FromBytes(ReadOnlySpan<byte> bytes)
     {
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
         var bpb = new BiosParameterBlock
         {
-            OemId = EndianUtilities.BytesToString(bytes.Slice(0x03, 8)),
+            OemId = latin1Encoding.GetString(bytes.Slice(0x03, 8)),
             BytesPerSector = EndianUtilities.ToUInt16LittleEndian(bytes.Slice(0x0B)),
             TotalSectors16 = EndianUtilities.ToUInt16LittleEndian(bytes.Slice(0x13)),
             TotalSectors32 = EndianUtilities.ToUInt32LittleEndian(bytes.Slice(0x20)),
@@ -166,7 +169,9 @@ internal class BiosParameterBlock
 
     internal void ToBytes(Span<byte> buffer)
     {
-        EndianUtilities.StringToBytes(OemId, buffer.Slice(0x03, 8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        latin1Encoding.GetBytes(OemId, buffer.Slice(0x03, 8));
         EndianUtilities.WriteBytesLittleEndian(BytesPerSector, buffer.Slice(0x0B));
         buffer[0x0D] = EncodeSingleByteSize(SectorsPerCluster);
         EndianUtilities.WriteBytesLittleEndian(ReservedSectors, buffer.Slice(0x0E));

--- a/Library/DiscUtils.Ntfs/FixupRecordBase.cs
+++ b/Library/DiscUtils.Ntfs/FixupRecordBase.cs
@@ -86,7 +86,10 @@ internal abstract class FixupRecordBase
 
     public void FromBytes(Span<byte> buffer, bool ignoreMagic = false)
     {
-        var diskMagic = EndianUtilities.BytesToString(buffer.Slice(0x00, 4));
+        var diskMagic = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(buffer.Slice(0x00, 4));
+
         if (Magic == null)
         {
             Magic = diskMagic;
@@ -125,7 +128,10 @@ internal abstract class FixupRecordBase
 
         ProtectBuffer(buffer);
 
-        EndianUtilities.StringToBytes(Magic, buffer.Slice(0x00, 4));
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes(Magic, buffer.Slice(0x00, 4));
+
         EndianUtilities.WriteBytesLittleEndian(UpdateSequenceOffset, buffer.Slice(0x04));
         EndianUtilities.WriteBytesLittleEndian(UpdateSequenceCount, buffer.Slice(0x06));
 

--- a/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystemChecker.cs
@@ -426,7 +426,10 @@ public sealed class NtfsFileSystemChecker : DiscFileSystemChecker
         {
             mftStream.ReadExactly(recordData);
 
-            var magic = EndianUtilities.BytesToString(recordData, 0, 4);
+            var magic = EncodingUtilities
+                .GetLatin1Encoding()
+                .GetString(recordData, 0, 4);
+
             if (magic != "FILE")
             {
                 if (bitmap.IsPresent(index))

--- a/Library/DiscUtils.Registry/Cell.cs
+++ b/Library/DiscUtils.Registry/Cell.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
 
 namespace DiscUtils.Registry;
 
@@ -45,7 +45,10 @@ internal abstract class Cell : IByteArraySerializable
 
     internal static Cell Parse(RegistryHive hive, int index, ReadOnlySpan<byte> buffer)
     {
-        var type = EndianUtilities.BytesToString(buffer.Slice(0, 2));
+        var type = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(buffer.Slice(0, 2));
+
         Cell result = type switch
         {
             "nk" => new KeyNodeCell(index),

--- a/Library/DiscUtils.Registry/SecurityCell.cs
+++ b/Library/DiscUtils.Registry/SecurityCell.cs
@@ -73,9 +73,10 @@ internal sealed class SecurityCell : Cell
 
     public override void WriteTo(Span<byte> buffer)
     {
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
         var sd = SecurityDescriptor.GetSecurityDescriptorBinaryForm();
 
-        EndianUtilities.StringToBytes("sk", buffer.Slice(0, 2));
+        latin1Encoding.GetBytes("sk", buffer.Slice(0, 2));
         EndianUtilities.WriteBytesLittleEndian(PreviousIndex, buffer.Slice(0x04));
         EndianUtilities.WriteBytesLittleEndian(NextIndex, buffer.Slice(0x08));
         EndianUtilities.WriteBytesLittleEndian(UsageCount, buffer.Slice(0x0C));

--- a/Library/DiscUtils.Registry/SubKeyHashedListCell.cs
+++ b/Library/DiscUtils.Registry/SubKeyHashedListCell.cs
@@ -61,7 +61,9 @@ internal sealed class SubKeyHashedListCell : ListCell
 
     public override int ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        _hashType = EndianUtilities.BytesToString(buffer.Slice(0, 2));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        _hashType = latin1Encoding.GetString(buffer.Slice(0, 2));
         _numElements = EndianUtilities.ToInt16LittleEndian(buffer.Slice(2));
 
         _subKeyIndexes = new List<int>(_numElements);
@@ -77,7 +79,10 @@ internal sealed class SubKeyHashedListCell : ListCell
 
     public override void WriteTo(Span<byte> buffer)
     {
-        EndianUtilities.StringToBytes(_hashType, buffer.Slice(0, 2));
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes(_hashType, buffer.Slice(0, 2));
+
         EndianUtilities.WriteBytesLittleEndian(_numElements, buffer.Slice(0x2));
         for (var i = 0; i < _numElements; ++i)
         {

--- a/Library/DiscUtils.Registry/SubKeyIndirectListCell.cs
+++ b/Library/DiscUtils.Registry/SubKeyIndirectListCell.cs
@@ -69,7 +69,9 @@ internal sealed class SubKeyIndirectListCell : ListCell
 
     public override int ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        ListType = EndianUtilities.BytesToString(buffer.Slice(0, 2));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        ListType = latin1Encoding.GetString(buffer.Slice(0, 2));
         int numElements = EndianUtilities.ToInt16LittleEndian(buffer.Slice(2));
         CellIndexes = new List<int>(numElements);
 
@@ -83,7 +85,10 @@ internal sealed class SubKeyIndirectListCell : ListCell
 
     public override void WriteTo(Span<byte> buffer)
     {
-        EndianUtilities.StringToBytes(ListType, buffer.Slice(0, 2));
+        EncodingUtilities
+            .GetLatin1Encoding()
+            .GetBytes(ListType, buffer.Slice(0, 2));
+
         EndianUtilities.WriteBytesLittleEndian((ushort)CellIndexes.Count, buffer.Slice(2));
         for (var i = 0; i < CellIndexes.Count; ++i)
         {

--- a/Library/DiscUtils.Registry/ValueCell.cs
+++ b/Library/DiscUtils.Registry/ValueCell.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
 
 namespace DiscUtils.Registry;
 
@@ -64,7 +64,9 @@ internal sealed class ValueCell : Cell
 
         if ((_flags & ValueFlags.Named) != 0)
         {
-            Name = EndianUtilities.BytesToString(buffer.Slice(0x14, nameLen)).Trim('\0');
+            Name = EncodingUtilities
+                .GetLatin1Encoding()
+                .GetString(buffer.Slice(0x14, nameLen)).Trim('\0');
         }
 
         return 0x14 + nameLen;
@@ -85,7 +87,9 @@ internal sealed class ValueCell : Cell
             nameLen = Name.Length;
         }
 
-        EndianUtilities.StringToBytes("vk", buffer.Slice(0, 2));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        latin1Encoding.GetBytes("vk", buffer.Slice(0, 2));
         EndianUtilities.WriteBytesLittleEndian(nameLen, buffer.Slice(0x02));
         EndianUtilities.WriteBytesLittleEndian(DataLength, buffer.Slice(0x04));
         EndianUtilities.WriteBytesLittleEndian(DataIndex, buffer.Slice(0x08));
@@ -93,7 +97,7 @@ internal sealed class ValueCell : Cell
         EndianUtilities.WriteBytesLittleEndian((ushort)_flags, buffer.Slice(0x10));
         if (nameLen != 0)
         {
-            EndianUtilities.StringToBytes(Name, buffer.Slice(0x14, nameLen));
+            latin1Encoding.GetBytes(Name, buffer.Slice(0x14, nameLen));
         }
     }
 }

--- a/Library/DiscUtils.Sdi/FileHeader.cs
+++ b/Library/DiscUtils.Sdi/FileHeader.cs
@@ -45,7 +45,9 @@ internal class FileHeader
 
     public void ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Tag = EndianUtilities.BytesToString(buffer.Slice(0, 8));
+        Tag = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(buffer.Slice(0, 8));
 
         if (Tag != "$SDI0001")
         {

--- a/Library/DiscUtils.Sdi/SectionRecord.cs
+++ b/Library/DiscUtils.Sdi/SectionRecord.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
 
 namespace DiscUtils.Sdi;
 
@@ -37,7 +37,9 @@ internal class SectionRecord
 
     public void ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        SectionType = EndianUtilities.BytesToString(buffer.Slice(0, 8)).TrimEnd('\0');
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        SectionType = latin1Encoding.GetString(buffer.Slice(0, 8)).TrimEnd('\0');
         Attr = EndianUtilities.ToUInt64LittleEndian(buffer.Slice(8));
         Offset = EndianUtilities.ToInt64LittleEndian(buffer.Slice(16));
         Size = EndianUtilities.ToInt64LittleEndian(buffer.Slice(24));

--- a/Library/DiscUtils.SquashFs/DirectoryRecord.cs
+++ b/Library/DiscUtils.SquashFs/DirectoryRecord.cs
@@ -45,11 +45,13 @@ internal class DirectoryRecord : IByteArraySerializable
 
     public void WriteTo(Span<byte> buffer)
     {
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
         EndianUtilities.WriteBytesLittleEndian(Offset, buffer);
         EndianUtilities.WriteBytesLittleEndian(InodeNumber, buffer.Slice(2));
         EndianUtilities.WriteBytesLittleEndian((ushort)Type, buffer.Slice(4));
         EndianUtilities.WriteBytesLittleEndian((ushort)(Name.Length - 1), buffer.Slice(6));
-        EndianUtilities.StringToBytes(Name, buffer.Slice(8, Name.Length));
+        latin1Encoding.GetBytes(Name, buffer.Slice(8, Name.Length));
     }
 
     public static DirectoryRecord ReadFrom(MetablockReader reader)

--- a/Library/DiscUtils.SquashFs/MetablockReader.cs
+++ b/Library/DiscUtils.SquashFs/MetablockReader.cs
@@ -173,14 +173,17 @@ internal sealed class MetablockReader
     public string ReadString(int len)
     {
         var block = _context.ReadMetaBlock(_start + _currentBlockStart);
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
 
         if (block.Available - _currentOffset < len)
         {
             Span<byte> buffer = stackalloc byte[len];
             buffer = buffer.Slice(0, Read(buffer));
-            return EndianUtilities.BytesToString(buffer);
+            return latin1Encoding.GetString(buffer);
         }
-        var result = EndianUtilities.BytesToString(block.Data, _currentOffset, len);
+
+        var result = latin1Encoding.GetString(block.Data, _currentOffset, len);
+
         _currentOffset += len;
         return result;
     }

--- a/Library/DiscUtils.Streams/Util/CompatExtensions.cs
+++ b/Library/DiscUtils.Streams/Util/CompatExtensions.cs
@@ -1,5 +1,4 @@
-﻿using LTRData.Extensions.Async;
-using System;
+﻿using System;
 using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
@@ -8,6 +7,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using LTRData.Extensions.Async;
 
 namespace DiscUtils.Streams.Compatibility;
 
@@ -157,44 +157,6 @@ public static class CompatExtensions
         finally
         {
             ArrayPool<byte>.Shared.Return(bytesBuffer);
-        }
-    }
-
-    public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
-    {
-        var buffer = ArrayPool<byte>.Shared.Rent(bytes.Length);
-        try
-        {
-            bytes.CopyTo(buffer);
-            return encoding.GetString(buffer, 0, bytes.Length);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
-    }
-
-    public static int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
-    {
-        var str = ArrayPool<char>.Shared.Rent(chars.Length);
-        try
-        {
-            chars.CopyTo(str);
-            var buffer = ArrayPool<byte>.Shared.Rent(encoding.GetByteCount(str, 0, chars.Length));
-            try
-            {
-                var length = encoding.GetBytes(str, 0, chars.Length, buffer, 0);
-                buffer.AsSpan(0, length).CopyTo(bytes);
-                return length;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-        finally
-        {
-            ArrayPool<char>.Shared.Return(str);
         }
     }
 

--- a/Library/DiscUtils.Streams/Util/EncodingExtensions.cs
+++ b/Library/DiscUtils.Streams/Util/EncodingExtensions.cs
@@ -1,0 +1,55 @@
+﻿using System.Text;
+using System.Buffers;
+using System;
+
+namespace DiscUtils.Streams;
+
+public static class EncodingExtensions
+{
+    public static int GetBytes(this Encoding encoding, string chars, Span<byte> bytes)
+    {
+        return encoding.GetBytes(chars.AsSpan(), bytes);
+    }
+
+#if !NETSTANDARD2_1_OR_GREATER && !NETCOREAPP
+    public static int GetBytes(this Encoding encoding, ReadOnlySpan<char> chars, Span<byte> bytes)
+    {
+        var str = ArrayPool<char>.Shared.Rent(chars.Length);
+        try
+        {
+            chars.CopyTo(str);
+            var buffer = ArrayPool<byte>.Shared.Rent(encoding.GetByteCount(str, 0, chars.Length));
+            try
+            {
+                var length = encoding.GetBytes(str, 0, chars.Length, buffer, 0);
+                buffer.AsSpan(0, length).CopyTo(bytes);
+                return length;
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(str);
+        }
+    }
+#endif
+
+#if !NETSTANDARD2_1_OR_GREATER && !NETCOREAPP
+    public static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        var buffer = ArrayPool<byte>.Shared.Rent(bytes.Length);
+        try
+        {
+            bytes.CopyTo(buffer);
+            return encoding.GetString(buffer, 0, bytes.Length);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+#endif
+}

--- a/Library/DiscUtils.Streams/Util/EncodingUtilities.cs
+++ b/Library/DiscUtils.Streams/Util/EncodingUtilities.cs
@@ -1,0 +1,20 @@
+﻿using System.Text;
+
+namespace DiscUtils.Streams;
+
+public static class EncodingUtilities
+{
+    /// <summary>
+    /// Retrieve the Latin1 encoding. This encoding is also known as iso-8859-1,
+    /// by its codepage 28591, and by its Windows codepage 1252.
+    /// </summary>
+    /// <returns>Encoding</returns>
+    public static Encoding GetLatin1Encoding()
+    {
+#if NET6_0_OR_GREATER
+        return Encoding.Latin1;
+#else
+        return Encoding.GetEncoding("Latin1");
+#endif
+    }
+}

--- a/Library/DiscUtils.Streams/Util/EndianUtilities.cs
+++ b/Library/DiscUtils.Streams/Util/EndianUtilities.cs
@@ -596,121 +596,6 @@ public static class EndianUtilities
     }
 
     /// <summary>
-    /// Primitive conversion from Unicode to ASCII that preserves special characters.
-    /// </summary>
-    /// <param name="value">The string to convert.</param>
-    /// <param name="dest">The buffer to fill.</param>
-    /// <param name="offset">The start of the string in the buffer.</param>
-    /// <param name="count">The number of characters to convert.</param>
-    /// <remarks>The built-in ASCIIEncoding converts characters of codepoint > 127 to ?,
-    /// this preserves those code points by removing the top 16 bits of each character.</remarks>
-    public static void StringToBytes(string value, byte[] dest, int offset, int count)
-    {
-        Encoding.GetEncoding(28591).GetBytes(value, 0, Math.Min(count, value.Length), dest, offset);
-    }
-
-    /// <summary>
-    /// Primitive conversion from Unicode to ASCII that preserves special characters.
-    /// </summary>
-    /// <param name="value">The string to convert.</param>
-    /// <param name="dest">The buffer to fill.</param>
-    /// <remarks>The built-in ASCIIEncoding converts characters of codepoint > 127 to ?,
-    /// this preserves those code points by removing the top 16 bits of each character.</remarks>
-    public static void StringToBytes(string value, Span<byte> dest)
-    {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-        Encoding.GetEncoding(28591).GetBytes(value.AsSpan(0, Math.Min(dest.Length, value.Length)), dest);
-#else
-        var buffer = ArrayPool<byte>.Shared.Rent(dest.Length);
-        try
-        {
-            Array.Clear(buffer, 0, dest.Length);
-            StringToBytes(value, buffer, 0, dest.Length);
-            buffer.AsSpan(0, dest.Length).CopyTo(dest);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
-#endif
-    }
-
-    /// <summary>
-    /// Primitive conversion from Unicode to ASCII that preserves special characters.
-    /// </summary>
-    /// <param name="value">The string to convert.</param>
-    /// <param name="dest">The buffer to fill.</param>
-    /// <remarks>The built-in ASCIIEncoding converts characters of codepoint > 127 to ?,
-    /// this preserves those code points by removing the top 16 bits of each character.</remarks>
-    public static int StringToBytes(ReadOnlySpan<char> value, Span<byte> dest)
-    {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-        return Encoding.GetEncoding(28591).GetBytes(value.Slice(0, Math.Min(dest.Length, value.Length)), dest);
-#else
-        var chars = ArrayPool<char>.Shared.Rent(value.Length);
-        try
-        {
-            value.CopyTo(chars);
-            var buffer = ArrayPool<byte>.Shared.Rent(dest.Length);
-            try
-            {
-                Array.Clear(buffer, 0, dest.Length);
-                var numBytes = Encoding.GetEncoding(28591).GetBytes(chars, 0, value.Length, buffer, 0);
-                buffer.AsSpan(0, numBytes).CopyTo(dest);
-                return numBytes;
-            }
-            finally
-            {
-                ArrayPool<byte>.Shared.Return(buffer);
-            }
-        }
-        finally
-        {
-            ArrayPool<char>.Shared.Return(chars);
-        }
-#endif
-    }
-
-    /// <summary>
-    /// Primitive conversion from ASCII to Unicode that preserves special characters.
-    /// </summary>
-    /// <param name="data">The data to convert.</param>
-    /// <param name="offset">The first byte to convert.</param>
-    /// <param name="count">The number of bytes to convert.</param>
-    /// <returns>The string.</returns>
-    /// <remarks>The built-in ASCIIEncoding converts characters of codepoint > 127 to ?,
-    /// this preserves those code points.</remarks>
-    public static string BytesToString(byte[] data, int offset, int count)
-    {
-        return Encoding.GetEncoding(28591).GetString(data, offset, count);
-    }
-
-    /// <summary>
-    /// Primitive conversion from ASCII to Unicode that preserves special characters.
-    /// </summary>
-    /// <param name="data">The data to convert.</param>
-    /// <returns>The string.</returns>
-    /// <remarks>The built-in ASCIIEncoding converts characters of codepoint > 127 to ?,
-    /// this preserves those code points.</remarks>
-    public static string BytesToString(ReadOnlySpan<byte> data)
-    {
-#if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-        return Encoding.GetEncoding(28591).GetString(data);
-#else
-        var buffer = ArrayPool<byte>.Shared.Rent(data.Length);
-        try
-        {
-            data.CopyTo(buffer);
-            return Encoding.GetEncoding(28591).GetString(buffer, 0, data.Length);
-        }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
-#endif
-    }
-
-    /// <summary>
     /// Primitive conversion from ASCII to Unicode that stops at a null-terminator.
     /// </summary>
     /// <param name="data">The data to convert.</param>
@@ -728,7 +613,7 @@ public static class EndianUtilities
             count = z - offset;
         }
 
-        return Encoding.GetEncoding(28591).GetString(data, offset, count);
+        return EncodingUtilities.GetLatin1Encoding().GetString(data, offset, count);
     }
 
     /// <summary>
@@ -748,13 +633,13 @@ public static class EndianUtilities
         }
 
 #if NETSTANDARD2_1_OR_GREATER || NETCOREAPP
-        return Encoding.GetEncoding(28591).GetString(data);
+        return EncodingUtilities.GetLatin1Encoding().GetString(data);
 #else
         var buffer = ArrayPool<byte>.Shared.Rent(data.Length);
         try
         {
             data.CopyTo(buffer);
-            return Encoding.GetEncoding(28591).GetString(buffer, 0, data.Length);
+            return EncodingUtilities.GetLatin1Encoding().GetString(buffer, 0, data.Length);
         }
         finally
         {

--- a/Library/DiscUtils.Swap/SwapHeader.cs
+++ b/Library/DiscUtils.Swap/SwapHeader.cs
@@ -53,17 +53,28 @@ public class SwapHeader : IByteArraySerializable
 
     public int ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Magic = EndianUtilities.BytesToString(buffer.Slice(PageSize - 10, 10));
-        if (Magic != Magic1 && Magic != Magic2) return Size;
+        Magic = EncodingUtilities
+            .GetLatin1Encoding()
+            .GetString(buffer.Slice(PageSize - 10, 10));
+
+        if (Magic != Magic1 && Magic != Magic2)
+        {
+            return Size;
+        }
 
         Version = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x400));
         LastPage = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x404));
         BadPages = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x408));
         Uuid = EndianUtilities.ToGuidLittleEndian(buffer.Slice(0x40c));
+
         var volume = buffer.Slice(0x41c, 16);
         var nullIndex = volume.IndexOf((byte)0);
+
         if (nullIndex > 0)
+        {
             Volume = Encoding.UTF8.GetString(volume.Slice(0, nullIndex));
+        }
+
         return Size;
     }
 

--- a/Library/DiscUtils.Vdi/HeaderRecord.cs
+++ b/Library/DiscUtils.Vdi/HeaderRecord.cs
@@ -106,11 +106,13 @@ internal class HeaderRecord
 
     public int Read(FileVersion version, ReadOnlySpan<byte> buffer)
     {
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
         if (version.Major == 0)
         {
             ImageType = (ImageType)EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0));
             Flags = (ImageFlags)EndianUtilities.ToUInt32LittleEndian(buffer.Slice(4));
-            Comment = EndianUtilities.BytesToString(buffer.Slice(8, 256)).TrimEnd('\0');
+            Comment = latin1Encoding.GetString(buffer.Slice(8, 256)).TrimEnd('\0');
             LegacyGeometry = new GeometryRecord();
             LegacyGeometry.Read(buffer.Slice(264));
             DiskSize = EndianUtilities.ToInt64LittleEndian(buffer.Slice(280));
@@ -131,7 +133,7 @@ internal class HeaderRecord
             HeaderSize = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0));
             ImageType = (ImageType)EndianUtilities.ToUInt32LittleEndian(buffer.Slice(4));
             Flags = (ImageFlags)EndianUtilities.ToUInt32LittleEndian(buffer.Slice(8));
-            Comment = EndianUtilities.BytesToString(buffer.Slice(12, 256)).TrimEnd('\0');
+            Comment = latin1Encoding.GetString(buffer.Slice(12, 256)).TrimEnd('\0');
             BlocksOffset = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(268));
             DataOffset = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(272));
             LegacyGeometry = new GeometryRecord();
@@ -183,11 +185,13 @@ internal class HeaderRecord
 
     public int Write(Span<byte> buffer)
     {
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
         if (_fileVersion.Major == 0)
         {
             EndianUtilities.WriteBytesLittleEndian((uint)ImageType, buffer.Slice(0));
             EndianUtilities.WriteBytesLittleEndian((uint)Flags, buffer.Slice(4));
-            EndianUtilities.StringToBytes(Comment, buffer.Slice(8, 256));
+            latin1Encoding.GetBytes(Comment.AsSpan(), buffer.Slice(8, 256));
             LegacyGeometry.Write(buffer.Slice(264));
             EndianUtilities.WriteBytesLittleEndian(DiskSize, buffer.Slice(280));
             EndianUtilities.WriteBytesLittleEndian(BlockSize, buffer.Slice(288));
@@ -202,7 +206,7 @@ internal class HeaderRecord
             EndianUtilities.WriteBytesLittleEndian(HeaderSize, buffer.Slice(0));
             EndianUtilities.WriteBytesLittleEndian((uint)ImageType, buffer.Slice(4));
             EndianUtilities.WriteBytesLittleEndian((uint)Flags, buffer.Slice(8));
-            EndianUtilities.StringToBytes(Comment, buffer.Slice(12, 256));
+            latin1Encoding.GetBytes(Comment.AsSpan(), buffer.Slice(12, 256));
             EndianUtilities.WriteBytesLittleEndian(BlocksOffset, buffer.Slice(268));
             EndianUtilities.WriteBytesLittleEndian(DataOffset, buffer.Slice(272));
             LegacyGeometry.Write(buffer.Slice(276));

--- a/Library/DiscUtils.Vdi/PreHeaderRecord.cs
+++ b/Library/DiscUtils.Vdi/PreHeaderRecord.cs
@@ -49,7 +49,9 @@ internal class PreHeaderRecord
 
     public int Read(ReadOnlySpan<byte> buffer)
     {
-        FileInfo = EndianUtilities.BytesToString(buffer.Slice(0, 64)).TrimEnd('\0');
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        FileInfo = latin1Encoding.GetString(buffer.Slice(0, 64)).TrimEnd('\0');
         Signature = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(64));
         Version = new FileVersion(EndianUtilities.ToUInt32LittleEndian(buffer.Slice(68)));
         return Size;
@@ -71,7 +73,9 @@ internal class PreHeaderRecord
 
     public void Write(Span<byte> buffer)
     {
-        EndianUtilities.StringToBytes(FileInfo, buffer.Slice(0, 64));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        latin1Encoding.GetBytes(FileInfo.AsSpan(), buffer.Slice(0, 64));
         EndianUtilities.WriteBytesLittleEndian(Signature, buffer.Slice(64));
         EndianUtilities.WriteBytesLittleEndian(Version.Value, buffer.Slice(68));
     }

--- a/Library/DiscUtils.Vhd/DynamicHeader.cs
+++ b/Library/DiscUtils.Vhd/DynamicHeader.cs
@@ -86,9 +86,11 @@ internal class DynamicHeader
 
     public static DynamicHeader FromBytes(ReadOnlySpan<byte> data)
     {
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
         var result = new DynamicHeader
         {
-            Cookie = EndianUtilities.BytesToString(data.Slice(0, 8)),
+            Cookie = latin1Encoding.GetString(data.Slice(0, 8)),
             DataOffset = EndianUtilities.ToInt64BigEndian(data.Slice(8)),
             TableOffset = EndianUtilities.ToInt64BigEndian(data.Slice(16)),
             HeaderVersion = EndianUtilities.ToUInt32BigEndian(data.Slice(24)),
@@ -98,9 +100,9 @@ internal class DynamicHeader
             ParentUniqueId = EndianUtilities.ToGuidBigEndian(data.Slice(40)),
             ParentTimestamp = Footer.EpochUtc.AddSeconds(EndianUtilities.ToUInt32BigEndian(data.Slice(56))),
             ParentUnicodeName = Encoding.BigEndianUnicode.GetString(data.Slice(64, 512)).TrimEnd('\0'),
-
             ParentLocators = new ParentLocator[8]
         };
+
         for (var i = 0; i < 8; ++i)
         {
             result.ParentLocators[i] = ParentLocator.FromBytes(data.Slice(576 + i * 24));
@@ -111,7 +113,9 @@ internal class DynamicHeader
 
     public void ToBytes(Span<byte> data)
     {
-        EndianUtilities.StringToBytes(Cookie, data.Slice(0, 8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        latin1Encoding.GetBytes(Cookie.AsSpan(), data.Slice(0, 8));
         EndianUtilities.WriteBytesBigEndian(DataOffset, data.Slice(8));
         EndianUtilities.WriteBytesBigEndian(TableOffset, data.Slice(16));
         EndianUtilities.WriteBytesBigEndian(HeaderVersion, data.Slice(24));

--- a/Library/DiscUtils.Vhd/Footer.cs
+++ b/Library/DiscUtils.Vhd/Footer.cs
@@ -22,6 +22,7 @@
 
 using System;
 using DiscUtils.Streams;
+using DiscUtils.Streams.Compatibility;
 
 namespace DiscUtils.Vhd;
 
@@ -143,16 +144,18 @@ internal class Footer
 
     public static Footer FromBytes(ReadOnlySpan<byte> buffer)
     {
-        var result = new Footer
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        return new Footer
         {
-            Cookie = EndianUtilities.BytesToString(buffer.Slice(0, 8)),
+            Cookie = latin1Encoding.GetString(buffer.Slice(0, 8)),
             Features = EndianUtilities.ToUInt32BigEndian(buffer.Slice(8)),
             FileFormatVersion = EndianUtilities.ToUInt32BigEndian(buffer.Slice(12)),
             DataOffset = EndianUtilities.ToInt64BigEndian(buffer.Slice(16)),
             Timestamp = EpochUtc.AddSeconds(EndianUtilities.ToUInt32BigEndian(buffer.Slice(24))),
-            CreatorApp = EndianUtilities.BytesToString(buffer.Slice(28, 4)),
+            CreatorApp = latin1Encoding.GetString(buffer.Slice(28, 4)),
             CreatorVersion = EndianUtilities.ToUInt32BigEndian(buffer.Slice(32)),
-            CreatorHostOS = EndianUtilities.BytesToString(buffer.Slice(36, 4)),
+            CreatorHostOS = latin1Encoding.GetString(buffer.Slice(36, 4)),
             OriginalSize = EndianUtilities.ToInt64BigEndian(buffer.Slice(40)),
             CurrentSize = EndianUtilities.ToInt64BigEndian(buffer.Slice(48)),
             Geometry = new Geometry(EndianUtilities.ToUInt16BigEndian(buffer.Slice(56)), buffer[58], buffer[59]),
@@ -161,20 +164,20 @@ internal class Footer
             UniqueId = EndianUtilities.ToGuidBigEndian(buffer.Slice(68)),
             SavedState = buffer[84]
         };
-
-        return result;
     }
 
     public void ToBytes(Span<byte> buffer)
     {
-        EndianUtilities.StringToBytes(Cookie, buffer.Slice(0, 8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        latin1Encoding.GetBytes(Cookie.AsSpan(), buffer.Slice(0, 8));
         EndianUtilities.WriteBytesBigEndian(Features, buffer.Slice(8));
         EndianUtilities.WriteBytesBigEndian(FileFormatVersion, buffer.Slice(12));
         EndianUtilities.WriteBytesBigEndian(DataOffset, buffer.Slice(16));
         EndianUtilities.WriteBytesBigEndian((uint)(Timestamp - EpochUtc).TotalSeconds, buffer.Slice(24));
-        EndianUtilities.StringToBytes(CreatorApp, buffer.Slice(28, 4));
+        latin1Encoding.GetBytes(CreatorApp.AsSpan(), buffer.Slice(28, 4));
         EndianUtilities.WriteBytesBigEndian(CreatorVersion, buffer.Slice(32));
-        EndianUtilities.StringToBytes(CreatorHostOS, buffer.Slice(36, 4));
+        latin1Encoding.GetBytes(CreatorHostOS.AsSpan(), buffer.Slice(36, 4));
         EndianUtilities.WriteBytesBigEndian(OriginalSize, buffer.Slice(40));
         EndianUtilities.WriteBytesBigEndian(CurrentSize, buffer.Slice(48));
         EndianUtilities.WriteBytesBigEndian((ushort)Geometry.Cylinders, buffer.Slice(56));

--- a/Library/DiscUtils.Vhd/Header.cs
+++ b/Library/DiscUtils.Vhd/Header.cs
@@ -40,11 +40,12 @@ internal class Header
 
     public static Header FromBytes(ReadOnlySpan<byte> data)
     {
-        var result = new Header
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        return new Header
         {
-            Cookie = EndianUtilities.BytesToString(data.Slice(0, 8)),
+            Cookie = latin1Encoding.GetString(data.Slice(0, 8)),
             DataOffset = EndianUtilities.ToInt64BigEndian(data.Slice(8))
         };
-        return result;
     }
 }

--- a/Library/DiscUtils.Vhd/ParentLocator.cs
+++ b/Library/DiscUtils.Vhd/ParentLocator.cs
@@ -20,8 +20,9 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
+using DiscUtils.Streams.Compatibility;
 
 namespace DiscUtils.Vhd;
 
@@ -50,19 +51,22 @@ internal class ParentLocator
 
     public static ParentLocator FromBytes(ReadOnlySpan<byte> data)
     {
-        var result = new ParentLocator
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        return new ParentLocator
         {
-            PlatformCode = EndianUtilities.BytesToString(data.Slice(0, 4)),
+            PlatformCode = latin1Encoding.GetString(data.Slice(0, 4)),
             PlatformDataSpace = EndianUtilities.ToInt32BigEndian(data.Slice(4)),
             PlatformDataLength = EndianUtilities.ToInt32BigEndian(data.Slice(8)),
             PlatformDataOffset = EndianUtilities.ToInt64BigEndian(data.Slice(16))
         };
-        return result;
     }
 
     internal void ToBytes(Span<byte> data)
     {
-        EndianUtilities.StringToBytes(PlatformCode, data.Slice(0, 4));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        latin1Encoding.GetBytes(PlatformCode.AsSpan(), data.Slice(0, 4));
         EndianUtilities.WriteBytesBigEndian(PlatformDataSpace, data.Slice(4));
         EndianUtilities.WriteBytesBigEndian(PlatformDataLength, data.Slice(8));
         EndianUtilities.WriteBytesBigEndian((uint)0, data.Slice(12));

--- a/Library/DiscUtils.Vhdx/DiskImageFileInfo.cs
+++ b/Library/DiscUtils.Vhdx/DiskImageFileInfo.cs
@@ -210,7 +210,10 @@ public sealed class DiskImageFileInfo
         {
             Span<byte> buffer = stackalloc byte[8];
             EndianUtilities.WriteBytesLittleEndian(_fileHeader.Signature, buffer);
-            return EndianUtilities.BytesToString(buffer);
+
+            return EncodingUtilities
+                .GetLatin1Encoding()
+                .GetString(buffer);
         }
     }
 }

--- a/Library/DiscUtils.Vhdx/HeaderInfo.cs
+++ b/Library/DiscUtils.Vhdx/HeaderInfo.cs
@@ -117,7 +117,10 @@ public sealed class HeaderInfo
         {
             Span<byte> buffer = stackalloc byte[4];
             EndianUtilities.WriteBytesLittleEndian(_header.Signature, buffer);
-            return EndianUtilities.BytesToString(buffer);
+
+            return EncodingUtilities
+                .GetLatin1Encoding()
+                .GetString(buffer);
         }
     }
 

--- a/Library/DiscUtils.Vhdx/MetadataTableInfo.cs
+++ b/Library/DiscUtils.Vhdx/MetadataTableInfo.cs
@@ -59,7 +59,10 @@ public sealed class MetadataTableInfo : ICollection<MetadataInfo>
         {
             Span<byte> buffer = stackalloc byte[8];
             EndianUtilities.WriteBytesLittleEndian(_table.Signature, buffer);
-            return EndianUtilities.BytesToString(buffer);
+
+            return EncodingUtilities
+                .GetLatin1Encoding()
+                .GetString(buffer);
         }
     }
 

--- a/Library/DiscUtils.Vhdx/RegionTableInfo.cs
+++ b/Library/DiscUtils.Vhdx/RegionTableInfo.cs
@@ -67,7 +67,10 @@ public sealed class RegionTableInfo : ICollection<RegionInfo>
         {
             Span<byte> buffer = stackalloc byte[4];
             EndianUtilities.WriteBytesLittleEndian(_table.Signature, buffer);
-            return EndianUtilities.BytesToString(buffer);
+
+            return EncodingUtilities
+                .GetLatin1Encoding()
+                .GetString(buffer);
         }
     }
 

--- a/Library/DiscUtils.Wim/FileHeader.cs
+++ b/Library/DiscUtils.Wim/FileHeader.cs
@@ -46,7 +46,9 @@ internal class FileHeader : IByteArraySerializable
 
     public int ReadFrom(ReadOnlySpan<byte> buffer)
     {
-        Tag = EndianUtilities.BytesToString(buffer.Slice(0, 8));
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        Tag = latin1Encoding.GetString(buffer.Slice(0, 8));
         HeaderSize = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(8));
         Version = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(12));
         Flags = (FileFlags)EndianUtilities.ToUInt32LittleEndian(buffer.Slice(16));

--- a/Library/DiscUtils.Xfs/BlockDirectoryDataEntry.cs
+++ b/Library/DiscUtils.Xfs/BlockDirectoryDataEntry.cs
@@ -20,8 +20,8 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
 
 namespace DiscUtils.Xfs;
 
@@ -79,6 +79,8 @@ internal class BlockDirectoryDataEntry : BlockDirectoryData, IDirectoryEntry
     /// <inheritdoc />
     public override string ToString()
     {
-        return $"{Inode}: {EndianUtilities.BytesToString(Name, 0, NameLength)}";
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        return $"{Inode}: {latin1Encoding.GetString(Name, 0, NameLength)}";
     }
 }

--- a/Library/DiscUtils.Xfs/ShortformDirectoryEntry.cs
+++ b/Library/DiscUtils.Xfs/ShortformDirectoryEntry.cs
@@ -20,10 +20,10 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
-namespace DiscUtils.Xfs;
-
-using DiscUtils.Streams;
 using System;
+using DiscUtils.Streams;
+
+namespace DiscUtils.Xfs;
 
 internal class ShortformDirectoryEntry : IByteArraySerializable, IDirectoryEntry
 {
@@ -81,6 +81,8 @@ internal class ShortformDirectoryEntry : IByteArraySerializable, IDirectoryEntry
     /// <inheritdoc />
     public override string ToString()
     {
-        return $"{Inode}: {EndianUtilities.BytesToString(Name, 0, NameLength)}";
+        var latin1Encoding = EncodingUtilities.GetLatin1Encoding();
+
+        return $"{Inode}: {latin1Encoding.GetString(Name, 0, NameLength)}";
     }
 }


### PR DESCRIPTION
Add utility to get the Latin1 encoding.
Get rid of Streams.BytesToString() and .StringToBytes() methods.
Provide extension methods on Encoding to take the place of deleted Streams methods.
Use Latin1 encoding like any other Encoding.
Fix LVM ID field decoding that relied on weird magic in the old StringToBytes() method.
Minor cleanup.