### PR TITLE
Adding progress tracking for files and directories

### DIFF
--- a/Library/DiscUtils.Iso9660/CDBuilder.cs
+++ b/Library/DiscUtils.Iso9660/CDBuilder.cs
@@ -56,6 +56,17 @@ public sealed class CDBuilder : StreamBuilder, IFileSystemBuilder
     private readonly List<BuildFileInfo> _files;
     private readonly BuildDirectoryInfo _rootDirectory;
 
+     // Define a delegate for progress reporting
+    public delegate void ProgressHandler(int currentProgress, int totalItems);
+    public event ProgressHandler ProgressChanged;
+
+ // Method for updating progress
+ private void UpdateProgress(int currentProgress, int totalItems)
+ {
+     ProgressChanged?.Invoke(currentProgress, totalItems);
+ }
+
+
     /// <summary>
     /// Initializes a new instance of the CDBuilder class.
     /// </summary>
@@ -203,6 +214,7 @@ public sealed class CDBuilder : StreamBuilder, IFileSystemBuilder
         var fi = new BuildFileInfo(nameElements[nameElements.Length - 1].ToString(), dir, content);
         AddFile(fi);
         dir.Add(fi);
+        UpdateProgress(_files.Count, _files.Count + _dirs.Count);
         return fi;
     }
 
@@ -227,6 +239,7 @@ public sealed class CDBuilder : StreamBuilder, IFileSystemBuilder
         var fi = new BuildFileInfo(nameElements[nameElements.Length - 1].ToString(), dir, sourcePath);
         AddFile(fi);
         dir.Add(fi);
+        UpdateProgress(_files.Count, _files.Count + _dirs.Count);
         return fi;
     }
 
@@ -256,6 +269,7 @@ public sealed class CDBuilder : StreamBuilder, IFileSystemBuilder
         var fi = new BuildFileInfo(nameElements[nameElements.Length - 1].ToString(), dir, source);
         AddFile(fi);
         dir.Add(fi);
+        UpdateProgress(_files.Count, _files.Count + _dirs.Count);
         return fi;
     }
 

--- a/Library/DiscUtils.Iso9660/CDBuilder.cs
+++ b/Library/DiscUtils.Iso9660/CDBuilder.cs
@@ -214,7 +214,9 @@ public sealed class CDBuilder : StreamBuilder, IFileSystemBuilder
         var fi = new BuildFileInfo(nameElements[nameElements.Length - 1].ToString(), dir, content);
         AddFile(fi);
         dir.Add(fi);
-        UpdateProgress(_files.Count, _files.Count + _dirs.Count);
+       int currentFilesCount = _files.Count;
+    int currentItemsCount = currentFilesCount + _dirs.Count;
+    UpdateProgress(currentFilesCount, currentItemsCount);
         return fi;
     }
 
@@ -239,7 +241,9 @@ public sealed class CDBuilder : StreamBuilder, IFileSystemBuilder
         var fi = new BuildFileInfo(nameElements[nameElements.Length - 1].ToString(), dir, sourcePath);
         AddFile(fi);
         dir.Add(fi);
-        UpdateProgress(_files.Count, _files.Count + _dirs.Count);
+        int currentFilesCount = _files.Count;
+    int currentItemsCount = currentFilesCount + _dirs.Count;
+    UpdateProgress(currentFilesCount, currentItemsCount);
         return fi;
     }
 
@@ -269,7 +273,9 @@ public sealed class CDBuilder : StreamBuilder, IFileSystemBuilder
         var fi = new BuildFileInfo(nameElements[nameElements.Length - 1].ToString(), dir, source);
         AddFile(fi);
         dir.Add(fi);
-        UpdateProgress(_files.Count, _files.Count + _dirs.Count);
+       int currentFilesCount = _files.Count;
+    int currentItemsCount = currentFilesCount + _dirs.Count;
+    UpdateProgress(currentFilesCount, currentItemsCount);
         return fi;
     }
 


### PR DESCRIPTION
This pull request introduces progress tracking for both files and directories during operations.

Added UpdateProgress(_files.Count, _files.Count + _dirs.Count); to update progress during operations.
Ensured accurate progress calculation for both files and directories.

The addition of progress tracking enhances user experience by providing real-time feedback during operations. Users will now have better visibility into the progress of file and directory operations, improving overall usability and user satisfaction.