### PR TITLE
Fix buffer management in LVM PhysicalVolume and VHDX LogEntry classes

### DIFF
--- a/Library/DiscUtils.Lvm/PhysicalVolume.cs
+++ b/Library/DiscUtils.Lvm/PhysicalVolume.cs
@@ -22,7 +22,6 @@
 
 
 using System;
-using System.Buffers;
 using System.IO;
 using DiscUtils.Partitions;
 using DiscUtils.Streams;
@@ -50,29 +49,8 @@ internal class PhysicalVolume
         {
             var area = PvHeader.MetadataDiskAreas[0];
 
-            var metadata = new VolumeGroupMetadata();
             content.Position = (long)area.Offset;
-
-            var areaLength = (int)area.Length;
-            byte[] metadataAlloc = null;
-            var metadataBuffer = areaLength <= 1024
-                ? stackalloc byte[areaLength]
-                : (metadataAlloc = ArrayPool<byte>.Shared.Rent(areaLength)).AsSpan(0, areaLength);
-
-            try
-            {
-                content.ReadExactly(metadataBuffer);
-                metadata.ReadFrom(metadataBuffer);
-            }
-            finally
-            {
-                if (metadataAlloc is not null)
-                {
-                    ArrayPool<byte>.Shared.Return(metadataAlloc);
-                }
-            }
-
-            VgMetadata = metadata;
+            VgMetadata = content.ReadStruct<VolumeGroupMetadata>((int)area.Length);
         }
 
         Content = content;

--- a/Library/DiscUtils.Lvm/PhysicalVolume.cs
+++ b/Library/DiscUtils.Lvm/PhysicalVolume.cs
@@ -22,6 +22,7 @@
 
 
 using System;
+using System.Buffers;
 using System.IO;
 using DiscUtils.Partitions;
 using DiscUtils.Streams;
@@ -40,7 +41,7 @@ internal class PhysicalVolume
     public PhysicalVolume(PhysicalVolumeLabel physicalVolumeLabel, Stream content)
     {
         PhysicalVolumeLabel = physicalVolumeLabel;
-        content.Position = (long) (physicalVolumeLabel.Sector * SECTOR_SIZE);
+        content.Position = (long)(physicalVolumeLabel.Sector * SECTOR_SIZE);
         Span<byte> buffer = stackalloc byte[SECTOR_SIZE];
         content.ReadExactly(buffer);
         PvHeader = new PvHeader();
@@ -48,10 +49,29 @@ internal class PhysicalVolume
         if (PvHeader.MetadataDiskAreas.Count > 0)
         {
             var area = PvHeader.MetadataDiskAreas[0];
+
             var metadata = new VolumeGroupMetadata();
-            content.Position = (long) area.Offset;
-            var metadataBuffer = StreamUtilities.ReadExactly(content, (int)area.Length);
-            metadata.ReadFrom(metadataBuffer);
+            content.Position = (long)area.Offset;
+
+            var areaLength = (int)area.Length;
+            byte[] metadataAlloc = null;
+            var metadataBuffer = areaLength <= 1024
+                ? stackalloc byte[areaLength]
+                : (metadataAlloc = ArrayPool<byte>.Shared.Rent(areaLength)).AsSpan(0, areaLength);
+
+            try
+            {
+                content.ReadExactly(metadataBuffer);
+                metadata.ReadFrom(metadataBuffer);
+            }
+            finally
+            {
+                if (metadataAlloc is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(metadataAlloc);
+                }
+            }
+
             VgMetadata = metadata;
         }
 

--- a/Library/DiscUtils.Lvm/PhysicalVolume.cs
+++ b/Library/DiscUtils.Lvm/PhysicalVolume.cs
@@ -50,9 +50,8 @@ internal class PhysicalVolume
             var area = PvHeader.MetadataDiskAreas[0];
             var metadata = new VolumeGroupMetadata();
             content.Position = (long) area.Offset;
-            buffer = stackalloc byte[(int)area.Length];
-            content.ReadExactly(buffer);
-            metadata.ReadFrom(buffer);
+            var metadataBuffer = StreamUtilities.ReadExactly(content, (int)area.Length);
+            metadata.ReadFrom(metadataBuffer);
             VgMetadata = metadata;
         }
 
@@ -74,7 +73,7 @@ internal class PhysicalVolume
         }
 
         pv = new PhysicalVolume(label, content);
-        
+
         return true;
     }
 

--- a/Library/DiscUtils.Vhdx/LogEntry.cs
+++ b/Library/DiscUtils.Vhdx/LogEntry.cs
@@ -105,9 +105,7 @@ internal sealed class LogEntry
         }
 
         var entryLength = checked((int)header.EntryLength);
-        var logEntryBuffer = entryLength <= 1024
-            ? (stackalloc byte[entryLength]).ToArray()
-            : ArrayPool<byte>.Shared.Rent(entryLength);
+        var logEntryBuffer = ArrayPool<byte>.Shared.Rent(entryLength);
 
         headerBuffer.CopyTo(logEntryBuffer);
 

--- a/Library/DiscUtils.Vhdx/LogEntry.cs
+++ b/Library/DiscUtils.Vhdx/LogEntry.cs
@@ -105,67 +105,60 @@ internal sealed class LogEntry
         }
 
         var entryLength = checked((int)header.EntryLength);
-        var logEntryBuffer = ArrayPool<byte>.Shared.Rent(entryLength);
+        var logEntryBuffer = new byte[entryLength];
 
-        try
+        headerBuffer.CopyTo(logEntryBuffer);
+
+        bytesToRead = entryLength - LogEntryHeader.ByteCount;
+        if (logStream.ReadMaximum(logEntryBuffer, LogEntryHeader.ByteCount, bytesToRead) != bytesToRead)
         {
-            headerBuffer.CopyTo(logEntryBuffer);
+            entry = null;
+            return false;
+        }
 
-            bytesToRead = entryLength - LogEntryHeader.ByteCount;
-            if (logStream.ReadMaximum(logEntryBuffer, LogEntryHeader.ByteCount, bytesToRead) != bytesToRead)
+        Array.Clear(logEntryBuffer, 4, sizeof(uint));
+        if (header.Checksum !=
+            Crc32LittleEndian.Compute(Crc32Algorithm.Castagnoli, logEntryBuffer, 0, entryLength))
+        {
+            entry = null;
+            return false;
+        }
+
+        var dataPos = MathUtilities.RoundUp((int)header.DescriptorCount * 32 + 64, LogSectorSize);
+
+        var descriptors = new List<Descriptor>();
+        for (var i = 0; i < header.DescriptorCount; ++i)
+        {
+            var offset = i * 32 + 64;
+            Descriptor descriptor;
+
+            var descriptorSig = EndianUtilities.ToUInt32LittleEndian(logEntryBuffer, offset);
+            switch (descriptorSig)
             {
-                entry = null;
-                return false;
-            }
-
-            Array.Clear(logEntryBuffer, 4, sizeof(uint));
-            if (header.Checksum !=
-                Crc32LittleEndian.Compute(Crc32Algorithm.Castagnoli, logEntryBuffer, 0, entryLength))
-            {
-                entry = null;
-                return false;
-            }
-
-            var dataPos = MathUtilities.RoundUp((int)header.DescriptorCount * 32 + 64, LogSectorSize);
-
-            var descriptors = new List<Descriptor>();
-            for (var i = 0; i < header.DescriptorCount; ++i)
-            {
-                var offset = i * 32 + 64;
-                Descriptor descriptor;
-
-                var descriptorSig = EndianUtilities.ToUInt32LittleEndian(logEntryBuffer, offset);
-                switch (descriptorSig)
-                {
-                    case Descriptor.ZeroDescriptorSignature:
-                        descriptor = new ZeroDescriptor();
-                        break;
-                    case Descriptor.DataDescriptorSignature:
-                        descriptor = new DataDescriptor(logEntryBuffer, dataPos);
-                        dataPos += LogSectorSize;
-                        break;
-                    default:
-                        entry = null;
-                        return false;
-                }
-
-                descriptor.ReadFrom(logEntryBuffer, offset);
-                if (!descriptor.IsValid(header.SequenceNumber))
-                {
+                case Descriptor.ZeroDescriptorSignature:
+                    descriptor = new ZeroDescriptor();
+                    break;
+                case Descriptor.DataDescriptorSignature:
+                    descriptor = new DataDescriptor(logEntryBuffer, dataPos);
+                    dataPos += LogSectorSize;
+                    break;
+                default:
                     entry = null;
                     return false;
-                }
-
-                descriptors.Add(descriptor);
             }
 
-            entry = new LogEntry(position, header, descriptors);
-            return true;
+            descriptor.ReadFrom(logEntryBuffer, offset);
+            if (!descriptor.IsValid(header.SequenceNumber))
+            {
+                entry = null;
+                return false;
+            }
+
+            descriptors.Add(descriptor);
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(logEntryBuffer);
-        }
+
+        entry = new LogEntry(position, header, descriptors);
+        return true;
     }
 
     private abstract class Descriptor : IByteArraySerializable

--- a/Library/DiscUtils.Vhdx/LogEntry.cs
+++ b/Library/DiscUtils.Vhdx/LogEntry.cs
@@ -105,7 +105,9 @@ internal sealed class LogEntry
         }
 
         var entryLength = checked((int)header.EntryLength);
-        var logEntryBuffer = new byte[entryLength];
+        var logEntryBuffer = entryLength <= 1024
+            ? (stackalloc byte[entryLength]).ToArray()
+            : ArrayPool<byte>.Shared.Rent(entryLength);
 
         headerBuffer.CopyTo(logEntryBuffer);
 

--- a/Library/DiscUtils.Vhdx/LogEntry.cs
+++ b/Library/DiscUtils.Vhdx/LogEntry.cs
@@ -105,7 +105,7 @@ internal sealed class LogEntry
         }
 
         var entryLength = checked((int)header.EntryLength);
-        var logEntryBuffer = ArrayPool<byte>.Shared.Rent(entryLength);
+        var logEntryBuffer = new byte[entryLength];
 
         headerBuffer.CopyTo(logEntryBuffer);
 
@@ -289,7 +289,7 @@ internal sealed class LogEntry
             EndianUtilities.WriteBytesLittleEndian(TrailingBytes, trailing);
 
             target.Write(leading);
-            target.Write(_data, _offset+8, 4084);
+            target.Write(_data, _offset + 8, 4084);
             target.Write(trailing);
         }
     }


### PR DESCRIPTION
 - Do not use stackalloc for disk metadata reads. It turns out that, in practice, the disk metadata area size can be large enough to cause a StackOverflowException. This means we cannot use stackalloc to instantiate the metadata buffer.
 - Do not use a shared pool for the VHDX LogEntry data buffer. The byte array reference is captured by the LogEntry instance and is not copied. ArrayPool can rent the same array to another consumer, which corrupts the state of the LogEntry instance that holds the reference to that array.

Both bugs were found while reading the contents of a fairly large VHDX file (~32 GB) containing an installed Ubuntu 24.04 OS with four EXT partitions.

Please let me know if you think there are better ways to fix these issues or if there is anything that is missing.

As a sidenote, I wanted to express that I greatly appreciate the amount of effort you put into modernizing and optimizing this codebase.