### PR TITLE
Add missing LVM2 volume section metadata fields

### DIFF
--- a/Library/DiscUtils.Lvm/MetadataPhysicalVolumeSection.cs
+++ b/Library/DiscUtils.Lvm/MetadataPhysicalVolumeSection.cs
@@ -31,11 +31,18 @@ internal class MetadataPhysicalVolumeSection
     public string Name;
     public string Id;
     public string Device;
+    public string DeviceHint;
+    public string DeviceId;
+    public string DeviceIdType;
     public PhysicalVolumeStatus Status;
     public string[] Flags;
     public ulong DeviceSize;
     public ulong PeStart;
     public ulong PeCount;
+    public ulong BaStart;
+    public ulong BaSize;
+    public string[] Tags;
+
 
     internal void Parse(string head, TextReader data)
     {
@@ -58,6 +65,15 @@ internal class MetadataPhysicalVolumeSection
                         break;
                     case "device":
                         Device = Metadata.ParseStringValue(parameter.Value.Span);
+                        break;
+                    case "device_hint":
+                        DeviceHint = Metadata.ParseStringValue(parameter.Value.Span);
+                        break;
+                    case "device_id":
+                        DeviceId = Metadata.ParseStringValue(parameter.Value.Span);
+                        break;
+                    case "device_id_type":
+                        DeviceIdType = Metadata.ParseStringValue(parameter.Value.Span);
                         break;
                     case "status":
                         var values = Metadata.ParseArrayValue(parameter.Value.Span);
@@ -84,6 +100,15 @@ internal class MetadataPhysicalVolumeSection
                         break;
                     case "pe_count":
                         PeCount = Metadata.ParseNumericValue(parameter.Value.Span);
+                        break;
+                    case "ba_start":
+                        BaStart = Metadata.ParseNumericValue(parameter.Value.Span);
+                        break;
+                    case "ba_size":
+                        BaSize = Metadata.ParseNumericValue(parameter.Value.Span);
+                        break;
+                    case "tags":
+                        Tags = Metadata.ParseArrayValue(parameter.Value.Span);
                         break;
                     default:
                         throw new ArgumentOutOfRangeException(parameter.Key.ToString(), "Unexpected parameter in global metadata");


### PR DESCRIPTION
Noticed that some fields are missing in LMV2 volume section metadata, and the code throws exception when an unknown field is present. Reproduced by trying to read contents of the VHDX file containing CentOS installation.

`MetadataPhysicalVolumeSection` class was first commited on [May 1, 2017 - LVM2 header & metadata parsing](https://github.com/DiscUtils/DiscUtils/commit/559874c9f7061c9da761ea3ca525804aee4488a2#diff-da8d187685d5ea0467cad039112199fc51c42ff60424d053c4338277200b9281).

There were 10 commits since May 1, 2017 ([LVM2 pv.h history](https://github.com/lvmteam/lvm2/commits/main/lib/metadata/pv.h)):
 - [Jul 20, 2017 - tidy: declaration names match implementation](https://github.com/lvmteam/lvm2/commit/876c4a1b3bdf2d2f9202438a406a803efa01bf9a) - rename refactoring
 - [May 14, 2018 - build: Don't generate symlinks in include/ dir](https://github.com/lvmteam/lvm2/commit/7f97c7ea9ade36bab817aca9eeee5c5177550127) - #include section update
 - [May 16, 2018 - device-mapper: Fork libdm internally.](https://github.com/lvmteam/lvm2/commit/ccc35e2647b3b78f2fb0d62c25f21fcccbf58950) - #include section update
 - [Jun 8, 2018 - device_mapper: rename libdevmapper.h -> all.h](https://github.com/lvmteam/lvm2/commit/286c1ba3369d1901480425e305e313e8ea365da4) - #include section update
 - [Nov 26, 2018 - Place the first PE at 1 MiB for all defaults](https://github.com/lvmteam/lvm2/commit/904e1e3d26ccb43c19266e96e67f8c10f93eaaa4) - refactoring, type definition name update
 - [Jun 7, 2019 - improve reading and repairing vg metadata](https://github.com/lvmteam/lvm2/commit/ba7ff96faff052c6145c71222ea5047a6bcee33b) - add unused_missing_cleared field with default value of 1
 - **[Sep 30, 2019 - metadata: import device name hint from metadata](https://github.com/lvmteam/lvm2/commit/3a8e41a67b3f0edb0fcb27302351f7d58b6ef8c5) - add `device_hint` property name**
 - **[Feb 23, 2021 - device usage based on devices file](https://github.com/lvmteam/lvm2/commit/83fe6e720f42711ff183a66909b690b726702f58) - add `device_id` and `device_id_type` fields**
 - [Aug 16, 2021 - cov: clean up pvid and vgid usage](https://github.com/lvmteam/lvm2/commit/96b777167c63eaf2e8ef1a2e7a92dc6c66cbcd6a) - rename refactoring of the vg id field
 - [Mar 6, 2025 - metadata: replace pv status WRONG_VG with pv bit field](https://github.com/lvmteam/lvm2/commit/951fd6358b9f57424def66e8f30c28cb1650213b) - add wrong_vg field with default value of 1

So, this list captures `device_hint`, `device_id` and `device_id_type` fields.

There are three more fields that are missing in current implementation: `ba_start`, `ba_size` and `tags`:
 - Commit where `ba_start` and `ba_size` were added in place of ea_start and ea_size: [May 28, 2013 - refactor: rename embedding area -> bootloader area](https://github.com/lvmteam/lvm2/commit/732859d21f3b41bdb188f92b60f25d5c94dcee8a#diff-0b1b98c852be805af9bd686545dbe5936e685dacc94368a9f5e086e241722d51)
 - `tags` existed since the very first commit: [May 28, 2013 - Add lib/metadata/pv.[ch] new files.](https://github.com/lvmteam/lvm2/commit/b88b638d6ec668b8fdf76238ab17221ca8643599#diff-0b1b98c852be805af9bd686545dbe5936e685dacc94368a9f5e086e241722d51)

I think this changeset is a short term solution, and I'd like to ask you to consider making parser more tolerant of unknown fields rather than throwing exceptions. LVM metadata format has evolved over time, and newer versions might include fields not present in current implementation. A more resilient approach would be to log unknown fields tather than failing.
