### PR TITLE
Linux software raid (fd partition) support

### DIFF
--- a/Library/DiscUtils.Core/Partitions/BiosPartitionTable.cs
+++ b/Library/DiscUtils.Core/Partitions/BiosPartitionTable.cs
@@ -665,6 +665,8 @@ public sealed class BiosPartitionTable : PartitionTable
                 return BiosPartitionTypes.Ntfs;
             case WellKnownPartitionType.Linux:
                 return BiosPartitionTypes.LinuxNative;
+			case WellKnownPartitionType.LinuxAutoRaid:
+				return BiosPartitionTypes.LinuxRaidAutoDetect;
             case WellKnownPartitionType.LinuxSwap:
                 return BiosPartitionTypes.LinuxSwap;
             case WellKnownPartitionType.LinuxLvm:

--- a/Library/DiscUtils.Core/Partitions/BiosPartitionTypes.cs
+++ b/Library/DiscUtils.Core/Partitions/BiosPartitionTypes.cs
@@ -102,6 +102,11 @@ public static class BiosPartitionTypes
     /// </summary>
     public const byte EfiSystem = 0xEF;
 
+	/// <summary>
+    /// Linux Raid Auto Detect
+    /// </summary>
+    public const byte LinuxRaidAutoDetect = 0xFD;
+
     /// <summary>
     /// Provides a string representation of some known BIOS partition types.
     /// </summary>
@@ -149,6 +154,7 @@ public static class BiosPartitionTypes
             0xEF => "EFI",
             0xFB => "VMware File System",
             0xFC => "VMware Swap",
+			0xFD => "Linux Raid Auto Detect",
             0xFE => "IBM OEM",
             _ => $"Unknown 0x{type:X2}",
         };

--- a/Library/DiscUtils.Core/Partitions/GuidPartitionTypes.cs
+++ b/Library/DiscUtils.Core/Partitions/GuidPartitionTypes.cs
@@ -59,6 +59,11 @@ public static class GuidPartitionTypes
     /// </summary>
     public static readonly Guid LinuxSwap = new("0657FD6D-A4AB-43C4-84E5-0933C84B4F4F");
 
+	/// <summary>
+    /// Linux Raid
+    /// </summary>
+    public static readonly Guid LinuxRaid = new("A19D880F-05FC-4D3B-A006-743F0F84911E");
+
     /// <summary>
     /// Windows Logical Disk Manager metadata.
     /// </summary>
@@ -94,6 +99,7 @@ public static class GuidPartitionTypes
         return wellKnown switch
         {
             WellKnownPartitionType.Linux or WellKnownPartitionType.WindowsFat or WellKnownPartitionType.WindowsNtfs => WindowsBasicData,
+			WellKnownPartitionType.LinuxAutoRaid => LinuxRaid,
             WellKnownPartitionType.LinuxLvm => LinuxLvm,
             WellKnownPartitionType.LinuxSwap => LinuxSwap,
             _ => throw new ArgumentException("Unknown partition type"),

--- a/Library/DiscUtils.Core/Partitions/WellKnownPartitionType.cs
+++ b/Library/DiscUtils.Core/Partitions/WellKnownPartitionType.cs
@@ -50,5 +50,9 @@ public enum WellKnownPartitionType
     /// <summary>
     /// Linux Logical Volume Manager (LVM).
     /// </summary>
-    LinuxLvm = 4
+    LinuxLvm = 4,
+	/// <summary>
+    /// Linux raid autodetect
+    /// </summary>
+    LinuxAutoRaid = 5,
 }

--- a/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidDiskGroup.cs
+++ b/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidDiskGroup.cs
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using DiscUtils.Streams;
+
+
+namespace DiscUtils.Lvm.LinuxRaid;
+using LogicalVolumeStatus=DiscUtils.LogicalVolumeStatus;
+internal class LinuxRaidDiskGroup : IDiagnosticTraceable {
+	private readonly List<LinuxRaidDiskVolume> _disks;
+	private readonly Guid _arrayUuid;
+	private readonly string _arrayName;
+	private readonly uint _raidLevel;
+
+	internal LinuxRaidDiskGroup(LinuxRaidDiskVolume initialDisk) {
+		_disks = [initialDisk];
+		_arrayUuid = initialDisk.ArrayUuid;
+		_arrayName = initialDisk.ArrayName;
+		_raidLevel = initialDisk.RaidLevel;
+	}
+
+	public Guid ArrayUuid => _arrayUuid;
+	public string ArrayName => _arrayName;
+	public uint RaidLevel => _raidLevel;
+	public int DiskCount => _disks.Count;
+
+	// Property to access the first disk for volume calculations
+	internal LinuxRaidDiskVolume FirstDisk => _disks.FirstOrDefault();
+
+	public void Dump(TextWriter writer, string linePrefix) {
+		writer.WriteLine($"{linePrefix}LINUX RAID ARRAY ({_arrayName})");
+		writer.WriteLine($"{linePrefix}  Array UUID: {_arrayUuid}");
+		writer.WriteLine($"{linePrefix}  Array Name: {_arrayName}");
+		writer.WriteLine($"{linePrefix}  RAID Level: {_raidLevel}");
+		writer.WriteLine($"{linePrefix}  Disk Count: {_disks.Count}");
+		writer.WriteLine();
+
+		writer.WriteLine($"{linePrefix}  MEMBER DISKS");
+		for (var i = 0; i < _disks.Count; i++) {
+			writer.WriteLine($"{linePrefix}    DISK {i}");
+			_disks[i].Dump(writer, $"{linePrefix}      ");
+		}
+	}
+
+	public void Add(LinuxRaidDiskVolume disk) {
+		if (disk.ArrayUuid != _arrayUuid) {
+			throw new InvalidOperationException("Cannot add disk with different array UUID to RAID group");
+		}
+
+		_disks.Add(disk);
+	}
+
+	internal IEnumerable<LinuxRaidVolume> GetVolumes() {
+		yield return new LinuxRaidVolume(this);
+	}
+
+	internal LogicalVolumeStatus GetVolumeStatus() =>  LogicalVolumeStatus.Healthy;
+
+	internal SparseStream OpenVolume() {
+		switch (_raidLevel) {
+			case 1: // RAID 1 - mirroring
+				return OpenRaid1Volume();
+			default:
+				throw new NotSupportedException($"RAID level {_raidLevel} is not currently supported");
+		}
+	}
+
+
+
+
+
+	private SparseStream OpenRaid1Volume() {
+		// RAID 1: mirror data across disks - read from first available disk
+		var memberStreams = _disks.Select(GetDiskStream).ToArray();
+
+		// For RAID 1, we can use mirror stream to provide redundancy
+		return new MirrorStream(Ownership.Dispose, memberStreams);
+	}
+
+
+
+	private SparseStream GetDiskStream(LinuxRaidDiskVolume disk) {
+		// If the disk is from a partition, open the partition stream and offset within it
+		if (disk.Partition != null) {
+			var partitionStream = disk.Partition.Open();
+			return new SubStream(partitionStream, Ownership.Dispose,
+				disk.DataOffset, (long)disk.ArraySize * Sizes.Sector);
+		} else {
+			// For whole disk RAID, use the disk content directly
+			return new SubStream(disk.PhysicalVolume.Open(), Ownership.Dispose,
+			disk.DataOffset, (long)disk.ArraySize * Sizes.Sector);
+		}
+	}
+}

--- a/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidDiskManagerFactory.cs
+++ b/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidDiskManagerFactory.cs
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using DiscUtils.Internal;
+using DiscUtils.Partitions;
+
+namespace DiscUtils.Lvm.LinuxRaid;
+
+[LogicalVolumeFactory]
+internal class LinuxRaidDiskManagerFactory : LogicalVolumeFactory {
+	public override bool HandlesPhysicalVolume(PhysicalVolumeInfo volume) {
+		var pi = volume.Partition;
+		if (pi == null)//i think even if is a full disk it creates a partition that is just the disk in size
+			return false;
+
+		if (IsLinuxRaidPartition(pi))
+			return true;
+		else {
+			var sb = LinuxRaidDiskVolume.GetSuperblock(volume.Partition);
+			if (sb?.IsValid == true)
+				return true;
+		}
+
+
+		return false; // We only handle partitions for now
+	}
+
+	public override void MapDisks(IEnumerable<VirtualDisk> disks, Dictionary<string, LogicalVolumeInfo> result) {
+		var raidPartitions = new List<LinuxRaidDiskVolume>();
+
+		// Find all Linux RAID partitions across all disks
+		foreach (var disk in disks) {
+			if (disk.IsPartitioned) {
+				foreach (var partition in disk.Partitions.Partitions) {
+					if (IsLinuxRaidPartition(partition)) {
+						// Create a temporary PhysicalVolumeInfo for this partition to test it
+
+						var partitionStream = partition.Open();
+
+						var superBlock = LinuxRaidDiskVolume.GetSuperblock(partition);
+						if (superBlock?.IsValid == true) {
+							var physicalVolume = new PhysicalVolumeInfo(superBlock.ArrayUuid.ToString(), disk, partition);
+							var raidDisk = new LinuxRaidDiskVolume(physicalVolume, superBlock);
+
+							// Only support RAID 1 for now
+							if (raidDisk.RaidLevel == 1)
+								raidPartitions.Add(raidDisk);
+
+						}
+					}
+				}
+			}
+		}
+
+		// Group RAID partitions by array UUID
+		var raidGroups = raidPartitions
+			.GroupBy(rp => rp.ArrayUuid)
+			.ToList();
+
+		// Create logical volumes for each complete RAID array
+		foreach (var group in raidGroups) {
+			var diskList = group.ToList();
+			if (diskList.Count > 0) {
+				var raidGroup = new LinuxRaidDiskGroup(diskList[0]);
+
+				// Create logical volume for this RAID array
+				foreach (var volume in raidGroup.GetVolumes()) {
+					var lvi = new LogicalVolumeInfo(
+						volume.Guid,
+						raidGroup.FirstDisk.PhysicalVolume,
+						volume.Open,
+						volume.Length,
+						volume.BiosType,
+						volume.Status,
+						GetTypeAsString(raidGroup.RaidLevel));
+					result.Add(lvi.Identity, lvi);
+				}
+			}
+		}
+	}
+
+	private static bool IsLinuxRaidPartition(PartitionInfo partition) {
+		// Check for Linux RAID partition types
+		return partition.BiosType == BiosPartitionTypes.LinuxRaidAutoDetect ||
+			   partition.GuidType == GuidPartitionTypes.LinuxRaid;
+	}
+
+	private static string GetTypeAsString(uint raidLevel) {
+		return raidLevel switch {
+			1 => "Linux RAID 1 (Mirror)",
+			_ => $"Linux RAID {raidLevel}"
+		};
+	}
+}

--- a/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidDiskVolume.cs
+++ b/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidDiskVolume.cs
@@ -1,0 +1,126 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using System.IO;
+using DiscUtils.Partitions;
+using DiscUtils.Streams;
+
+namespace DiscUtils.Lvm.LinuxRaid;
+
+internal class LinuxRaidDiskVolume : IDiagnosticTraceable {
+	private readonly PhysicalVolumeInfo _physicalVolume;
+	private readonly LinuxRaidSuperblock _superblock;
+
+	internal LinuxRaidDiskVolume(PhysicalVolumeInfo physicalVolume, LinuxRaidSuperblock superblock) {
+		_physicalVolume = physicalVolume;
+		_superblock = superblock;
+		if (_superblock?.IsValid != true)
+			throw new InvalidDataException("Invalid Linux RAID superblock");
+	}
+
+	public PhysicalVolumeInfo PhysicalVolume => _physicalVolume;
+
+	public LinuxRaidSuperblock Superblock => _superblock;
+
+	public long DataOffset => (long)_superblock.DataOffset * Sizes.Sector;
+
+	public Guid ArrayUuid => _superblock.ArrayUuid;
+
+	public uint RaidLevel => _superblock.RaidLevel;
+
+	public string ArrayName => _superblock.ArrayName;
+
+	public ulong ArraySize => _superblock.ArraySize;
+
+	public PartitionInfo Partition => _physicalVolume.Partition;
+
+	public void Dump(TextWriter writer, string linePrefix) {
+		writer.WriteLine($"{linePrefix}LINUX RAID DISK ({_superblock.ArrayName})");
+		writer.WriteLine($"{linePrefix}      RAID Version: {_superblock.MajorVersion}.{_superblock.MinorVersion}");
+		writer.WriteLine($"{linePrefix}        RAID Level: {_superblock.RaidLevel}");
+		writer.WriteLine($"{linePrefix}        Array UUID: {_superblock.ArrayUuid}");
+		writer.WriteLine($"{linePrefix}        Array Name: {_superblock.ArrayName}");
+		writer.WriteLine($"{linePrefix}       Data Offset: {_superblock.DataOffset} (Sectors)");
+		writer.WriteLine($"{linePrefix}        Array Size: {_superblock.ArraySize} (Sectors)");
+		writer.WriteLine($"{linePrefix}       Total Disks: {_superblock.TotalDisks}");
+	}
+
+	public enum MetadataVersion {
+		Version09,
+		Version10,
+		Version11,
+		Version12
+	}
+
+	internal static LinuxRaidSuperblock GetSuperblock(PartitionInfo partition) {
+		using var volumeStream = partition.Open();
+		var superblock = new LinuxRaidSuperblock();
+		Span<byte> buffer = stackalloc byte[4096]; // Large enough for any superblock
+
+		// Get superblock locations for the volume (these are relative to volume start, not disk start)
+		var locations = GetSuperblockLocations(partition);
+
+		foreach (var (version, offset) in locations) {
+			try {
+				volumeStream.Position = offset;
+				var bytesRead = volumeStream.Read(buffer);
+				if (bytesRead >= 512) // Minimum superblock size
+				{
+					superblock.ReadFrom(buffer.Slice(0, bytesRead), version);
+					if (superblock.IsValid) {
+						return superblock;
+					}
+				}
+			} catch {
+				// Continue to next location if this one fails
+			}
+		}
+
+		return null; // No valid superblock found
+	}
+
+
+	private static (MetadataVersion version, long offset)[] GetSuperblockLocations(PartitionInfo partition) {
+		var volumeSize = partition.SectorCount;
+		const int sectorSize = 512; // Standard sector size
+
+		return
+		[
+            // v1.1 - at the beginning of the volume (block 0)
+            (MetadataVersion.Version11, 0L),
+            
+            // v1.2 - at 4KB offset
+            (MetadataVersion.Version12, 4096L),
+            
+            // v1.0 - at the end of the volume minus 8KB, then aligned to 64KB boundary
+            (MetadataVersion.Version10, AlignDown(volumeSize - 8192, 65536)),
+            
+            // v0.9 - near the end of the volume
+            (MetadataVersion.Version09, AlignDown(volumeSize - 65536, sectorSize))
+		];
+	}
+
+	private static long AlignDown(long value, long alignment) {
+		return Math.Max(0, value / alignment * alignment);
+	}
+}

--- a/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidSuperblock.cs
+++ b/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidSuperblock.cs
@@ -1,0 +1,131 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using DiscUtils.Streams;
+
+namespace DiscUtils.Lvm.LinuxRaid;
+
+internal class LinuxRaidSuperblock {
+	// Magic identifier for Linux MD RAID
+	public const uint LinuxRaidMagic = 0xa92b4efc;
+
+	public uint Magic { get; private set; }
+	public uint MajorVersion { get; private set; }
+	public uint MinorVersion { get; private set; }
+	public uint RaidLevel { get; private set; }
+	public Guid ArrayUuid { get; private set; }
+	public string ArrayName { get; private set; }
+	public ulong DataOffset { get; private set; }
+	public ulong ArraySize { get; private set; }
+	public uint TotalDisks { get; private set; }
+
+	public bool IsValid => Magic == LinuxRaidMagic;
+
+	public void ReadFrom(ReadOnlySpan<byte> buffer, LinuxRaidDiskVolume.MetadataVersion version) {
+		Magic = EndianUtilities.ToUInt32LittleEndian(buffer);
+		if (!IsValid)
+			return;
+		MinorVersion = version switch {
+			LinuxRaidDiskVolume.MetadataVersion.Version09 => 9,
+			LinuxRaidDiskVolume.MetadataVersion.Version10 => 0,
+			LinuxRaidDiskVolume.MetadataVersion.Version11 => 1,
+			LinuxRaidDiskVolume.MetadataVersion.Version12 => 2,
+			_ => throw new InvalidOperationException($"Unexpected version {version}")
+		};
+		if (MinorVersion == 9)
+			ReadVersion09(buffer);
+		else
+			ReadVersion1x(buffer);
+	}
+	/*  Not sure why finding the 0.9 docs are hard for the spec but grub ( https://git.proxmox.com/?p=grub2.git;a=blob_plain;f=disk/mdraid_linux.c;hb=ee293aee1b13d9c1d1124226ecf95e1a70e4a936 ) provides it pretty clearly:
+	   grub_uint32_t md_magic;	//0 MD identifier.  
+grub_uint32_t major_version;	//1 Major version. 
+grub_uint32_t minor_version;	//2 Minor version.  
+grub_uint32_t patch_version;	//3 Patchlevel version.  
+grub_uint32_t gvalid_words;	//4 Number of used words in this section.  
+grub_uint32_t set_uuid0;	//5 Raid set identifier.  
+grub_uint32_t ctime;		//6 Creation time.  
+grub_uint32_t level;		//7 Raid personality.  
+grub_uint32_t size;		//8 Apparent size of each individual disk.  
+grub_uint32_t nr_disks;	//9 Total disks in the raid set.  
+grub_uint32_t raid_disks;	//10 Disks in a fully functional raid set.  
+grub_uint32_t md_minor;	//11 Preferred MD minor device number.  
+grub_uint32_t not_persistent;	//12 Does it have a persistent superblock.  
+grub_uint32_t set_uuid1;	//13 Raid set identifier #2.  
+grub_uint32_t set_uuid2;	//14 Raid set identifier #3.  
+grub_uint32_t set_uuid3;	//15 Raid set identifier #4.  
+grub_uint32_t gstate_creserved[SB_GENERIC_CONSTANT_WORDS - 16];
+	*/
+	private void ReadVersion09(ReadOnlySpan<byte> buffer) {
+		var uIntSize = 4;
+		DataOffset = 0;
+		MajorVersion = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(uIntSize * 1));
+		MinorVersion = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(uIntSize * 2));
+		if (MajorVersion != 0 || MinorVersion != 9) {
+			// Not actually version 0.9 despite being in the 0.9 location
+			Magic = 0;
+			return;
+		}
+		RaidLevel = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(uIntSize * 7));
+		var _uuidBytes = new byte[16];
+		Span<byte> uuidBytes = _uuidBytes;
+		buffer.Slice(uIntSize * 5, 4).CopyTo(uuidBytes);
+		buffer.Slice(uIntSize * 13, 4).CopyTo(uuidBytes.Slice(4));
+		buffer.Slice(uIntSize * 14, 4).CopyTo(uuidBytes.Slice(8));
+		buffer.Slice(uIntSize * 15, 4).CopyTo(uuidBytes.Slice(12));
+		ArrayUuid = new Guid(_uuidBytes);
+		ArrayName = "raid";
+		ArraySize = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(uIntSize * 8)) * 1024UL;
+		TotalDisks = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(uIntSize * 9));
+	}
+
+	private void ReadVersion1x(ReadOnlySpan<byte> buffer) {
+		// Version 1.x format https://archive.kernel.org/oldwiki/raid.wiki.kernel.org/index.php/RAID_superblock_formats.html#Sub-versions_of_the_version-1_superblock
+		MajorVersion = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x04));
+		if (MajorVersion != 1) {
+			// Not actually version 1.x despite being in the 1.x location
+			Magic = 0;
+			return;
+		}
+
+		// RAID level at offset 0x48
+		RaidLevel = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x48));
+
+		// Array UUID at offset 0x10-0x1F
+		var uuidBytes = new byte[16];
+		buffer.Slice(0x10, 16).CopyTo(uuidBytes);
+		ArrayUuid = new Guid(uuidBytes);
+
+		// Array name at offset 0x20-0x3F (32 bytes)
+		ArrayName = EndianUtilities.BytesToZString(buffer.Slice(0x20, 32));
+
+		// Data offset at offset 0x80 (8 bytes, little endian)
+		DataOffset = EndianUtilities.ToUInt64LittleEndian(buffer.Slice(0x80));
+
+		// Array size at offset 0x88 (8 bytes, sectors)
+		ArraySize = EndianUtilities.ToUInt64LittleEndian(buffer.Slice(0x88));
+
+		// Total disks at offset 0x9C
+		TotalDisks = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(0x5C));
+	}
+}

--- a/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidVolume.cs
+++ b/Library/DiscUtils.Lvm/LinuxRaid/LinuxRaidVolume.cs
@@ -1,0 +1,88 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using DiscUtils.Partitions;
+using DiscUtils.Streams;
+
+namespace DiscUtils.Lvm.LinuxRaid;
+using LogicalVolumeStatus=DiscUtils.LogicalVolumeStatus;
+internal class LinuxRaidVolume
+{
+    private readonly LinuxRaidDiskGroup _group;
+
+    internal LinuxRaidVolume(LinuxRaidDiskGroup group)
+    {
+        _group = group;
+    }
+
+	public Guid Guid => _group.ArrayUuid;
+
+	public string Identity => $"RAID:{Guid:D}";
+
+    public long Length => CalculateVolumeLength();
+
+    public byte BiosType => BiosPartitionTypes.LinuxRaidAutoDetect;
+
+    public LogicalVolumeStatus Status => _group.GetVolumeStatus();
+
+    public SparseStream Open()
+    {
+        return _group.OpenVolume();
+    }
+
+    private long CalculateVolumeLength()
+    {
+        var memberDiskSize = GetMemberDiskSize();
+        
+        switch (_group.RaidLevel)
+        {
+            case 0: // RAID 0 - total of all disks
+                return _group.DiskCount * memberDiskSize;
+
+            case 1: // RAID 1 - size of one disk (they're mirrors)
+                return memberDiskSize;
+
+            case 5: // RAID 5 - (n-1) * disk_size (one disk for parity)
+                return (_group.DiskCount - 1) * memberDiskSize;
+
+            case 6: // RAID 6 - (n-2) * disk_size (two disks for parity)
+                return Math.Max(0, _group.DiskCount - 2) * memberDiskSize;
+
+            default:
+                // For unknown RAID levels, return the size of the first disk
+                return memberDiskSize;
+        }
+    }
+
+    private long GetMemberDiskSize()
+    {
+        // Access the first disk through the exposed property
+        var firstDisk = _group.FirstDisk;
+        if (firstDisk != null)
+        {
+            // Convert from sectors to bytes
+            return (long)firstDisk.ArraySize * Sizes.Sector;
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
Only reading from Raid1

This should support all linux raid versions from 0.9 to the current 1.2.   0.9 technically probably works without this due to the logical volume starting at block 0,  but for anything else this makes it work.

Let me know if this should go into a new project rather than core, also I just left the copyright from most of the others on it.