### PR TITLE
Abstract record interface

### DIFF
--- a/Library/DiscUtils.Btrfs/BtrfsFileSystem.cs
+++ b/Library/DiscUtils.Btrfs/BtrfsFileSystem.cs
@@ -42,7 +42,8 @@ public sealed class BtrfsFileSystem : VfsFileSystemFacade, IUnixFileSystem, IAll
         : base(new VfsBtrfsFileSystem(stream))
     {
     }
-
+	public override IAbstractRecord GetAbstractRecord(string path) => GetRealFileSystem<VfsBtrfsFileSystem>().GetAbstractRecord(path);
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => GetRealFileSystem<VfsBtrfsFileSystem>().GetSymlinkTarget(dirEntry);
     /// <summary>
     /// Initializes a new instance of the BtrfsFileSystem class.
     /// </summary>

--- a/Library/DiscUtils.Btrfs/VfsBtrfsFileSystem.cs
+++ b/Library/DiscUtils.Btrfs/VfsBtrfsFileSystem.cs
@@ -131,7 +131,13 @@ internal sealed class VfsBtrfsFileSystem : VfsReadOnlyFileSystem<DirEntry, File,
             yield return new Subvolume { Id = volume.Key.Offset, Name = volume.Name };
         }
     }
+	protected override Directory ConvertDirEntryToDirectory(DirEntry dirEntry) {
+        if (dirEntry.IsDirectory)
+			throw new Exception("Invalid Directory Request record is not a directory");
+        
+        return dirEntry.CachedDirectory ??= new Directory(dirEntry, Context);
 
+	}
     protected override File ConvertDirEntryToFile(DirEntry dirEntry)
     {
         if (dirEntry.IsDirectory)

--- a/Library/DiscUtils.Core/DiscFileSystem.cs
+++ b/Library/DiscUtils.Core/DiscFileSystem.cs
@@ -25,6 +25,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using DiscUtils.Streams;
+using DiscUtils.Vfs;
 
 namespace DiscUtils;
 
@@ -519,6 +520,10 @@ public abstract class DiscFileSystem :
             Disposed?.Invoke(this, EventArgs.Empty);
         }
     }
+
+	public virtual IAbstractRecord GetAbstractRecord(string path) => throw new NotImplementedException();
+	public virtual string GetSymlinkTarget(IAbstractRecord dirEntry) => throw new NotImplementedException();
+
 
     public event EventHandler Disposed;
 

--- a/Library/DiscUtils.Core/DiscFileSystem.cs
+++ b/Library/DiscUtils.Core/DiscFileSystem.cs
@@ -521,9 +521,8 @@ public abstract class DiscFileSystem :
         }
     }
 
-	public virtual IAbstractRecord GetAbstractRecord(string path) => throw new NotImplementedException();
-	public virtual string GetSymlinkTarget(IAbstractRecord dirEntry) => throw new NotImplementedException();
-
+	public abstract IAbstractRecord GetAbstractRecord(string path);
+	public abstract string GetSymlinkTarget(IAbstractRecord dirEntry);
 
     public event EventHandler Disposed;
 

--- a/Library/DiscUtils.Core/IFileSystem.cs
+++ b/Library/DiscUtils.Core/IFileSystem.cs
@@ -370,4 +370,7 @@ public interface IFileSystem
     /// UsedSpace and Size properties
     /// </summary>
     bool SupportsUsedAvailableSpace { get; }
+
+	 Vfs.IAbstractRecord GetAbstractRecord(string path);
+	 string GetSymlinkTarget(Vfs.IAbstractRecord dirEntry);
 }

--- a/Library/DiscUtils.Core/NativeFileSystem.cs
+++ b/Library/DiscUtils.Core/NativeFileSystem.cs
@@ -29,6 +29,7 @@ using System.IO;
 using System.Linq;
 using DiscUtils.Internal;
 using DiscUtils.Streams;
+using DiscUtils.Vfs;
 
 namespace DiscUtils;
 
@@ -782,4 +783,7 @@ public class NativeFileSystem : DiscFileSystem
     {
         return dirtyItems.Substring(BasePath.Length - 1);
     }
+
+	public override IAbstractRecord GetAbstractRecord(string path) => throw new NotImplementedException();
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => throw new NotImplementedException();
 }

--- a/Library/DiscUtils.Core/NativeFileSystem.cs
+++ b/Library/DiscUtils.Core/NativeFileSystem.cs
@@ -783,7 +783,85 @@ public class NativeFileSystem : DiscFileSystem
     {
         return dirtyItems.Substring(BasePath.Length - 1);
     }
+	internal class NativeAbstractDirectory : NativeAbstractRecord, IAbstractDirectory {
+		private DirectoryInfo di;
 
-	public override IAbstractRecord GetAbstractRecord(string path) => throw new NotImplementedException();
-	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => throw new NotImplementedException();
+		public NativeAbstractDirectory(NativeFileSystem fs, DirectoryInfo di) : base(fs,di,true){
+			this.di = di;
+		}
+
+		public NativeAbstractDirectory(NativeFileSystem fs, String path) : this(fs,new DirectoryInfo(path)) {
+			
+		}
+
+		public IEnumerable<IAbstractRecord> AllEntries {
+			get{
+				foreach(var d in di.GetDirectories())
+					yield return new NativeAbstractDirectory(fs,d);
+				foreach(var d in di.GetFiles())
+					yield return new NativeAbstractRecord(fs,d,false);
+			}
+		}
+
+		
+	}
+	internal class NativeAbstractRecord : IAbstractRecord {
+		public NativeAbstractRecord(NativeFileSystem fs, String path){
+			info = new FileInfo(Path.Combine(fs.BasePath,path));
+			IsDirectory = false;
+			FileName = fs.CleanItems(info.FullName);
+			this.fs  = fs;
+		}
+		internal NativeAbstractRecord(NativeFileSystem fs, System.IO.FileSystemInfo info, bool isDirectory){
+			this.info = info;
+			IsDirectory = true;
+			FileName = fs.CleanItems(info.FullName);
+			this.fs  = fs;
+		}
+		protected System.IO.FileSystemInfo info;
+
+		public DateTime CreationTimeUtc => info.CreationTimeUtc;
+		public FileAttributes FileAttributes  => info.Attributes;
+		public string FileName {get; }
+
+		protected NativeFileSystem fs;
+
+		public virtual bool IsDirectory {get; }
+		public bool IsSymlink => info.LinkTarget != null;
+		public DateTime LastAccessTimeUtc => info.LastAccessTimeUtc;
+		public DateTime LastWriteTimeUtc => info.LastWriteTimeUtc;
+		public long FileId => throw new NotImplementedException(); // need native call for it or inode
+		public long FileSize => (info is FileInfo fi) ? fi.Length : 0;
+		public SparseStream FileContent => (info is FileInfo fi) ? fs.OpenFile(FileName, FileMode.Open, FileAccess.Read) : null;
+
+		public VfsDirEntry GetAsDirEntry() => throw new NotImplementedException();
+		public IVfsFile GetAsFile() => throw new NotImplementedException();
+		public IAbstractDirectory GetAsAbstractDirectory() => this as IAbstractDirectory;
+	}
+	public override IAbstractRecord GetAbstractRecord(string path) {
+		var truePath = Path.Combine(BasePath,path);
+		if (Directory.Exists(truePath)){
+			var di = new DirectoryInfo(truePath);
+			return new NativeAbstractRecord(this,di,true);
+		}
+		else if (File.Exists(truePath)){
+			return new NativeAbstractRecord(this,path);
+		}
+		else
+			return null;
+	}
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) {
+		if (! dirEntry.IsSymlink)
+			throw new ArgumentException("Not a symlink", nameof(dirEntry));
+		string target;
+		var ourPath = Path.Combine(BasePath, dirEntry.FileName);
+		if (dirEntry.IsDirectory)
+			target = Directory.ResolveLinkTarget(ourPath, false).FullName;
+		else {
+			target = File.ResolveLinkTarget(ourPath, false).FullName;
+		}
+		if (target.StartsWith(BasePath, StringComparison.CurrentCultureIgnoreCase) == false)
+			return null;
+		return CleanItems(target);
+	}
 }

--- a/Library/DiscUtils.Core/NativeFileSystem.cs
+++ b/Library/DiscUtils.Core/NativeFileSystem.cs
@@ -806,15 +806,11 @@ public class NativeFileSystem : DiscFileSystem
 		
 	}
 	internal class NativeAbstractRecord : IAbstractRecord {
-		public NativeAbstractRecord(NativeFileSystem fs, String path){
-			info = new FileInfo(Path.Combine(fs.BasePath,path));
-			IsDirectory = false;
-			FileName = fs.CleanItems(info.FullName);
-			this.fs  = fs;
+		public NativeAbstractRecord(NativeFileSystem fs, String path) : this (fs, new FileInfo(Path.Combine(fs.BasePath, path)), false) {
 		}
 		internal NativeAbstractRecord(NativeFileSystem fs, System.IO.FileSystemInfo info, bool isDirectory){
 			this.info = info;
-			IsDirectory = true;
+			IsDirectory = isDirectory;
 			FileName = fs.CleanItems(info.FullName);
 			this.fs  = fs;
 		}

--- a/Library/DiscUtils.Core/ReparsePoint.cs
+++ b/Library/DiscUtils.Core/ReparsePoint.cs
@@ -36,7 +36,7 @@ public sealed class ReparsePoint
     /// </summary>
     /// <param name="tag">The defined reparse point tag.</param>
     /// <param name="content">The reparse point's content.</param>
-    public ReparsePoint(int tag, byte[] content)
+    public ReparsePoint(uint tag, byte[] content)
     {
         Tag = tag;
         Content = content;
@@ -50,14 +50,17 @@ public sealed class ReparsePoint
     /// <summary>
     /// Gets or sets the defined reparse point tag.
     /// </summary>
-    public int Tag { get; set; }
+    public uint Tag { get; set; }
 	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/c8e77b37-3909-4fe6-a4ea-2b9d423b1ee4
-	private const int IO_REPARSE_TAG_MOUNT_POINT = unchecked((int)0xA0000003);
-	private const int IO_REPARSE_TAG_SYMLINK = unchecked((int)0xA000000C);
+	private const uint IO_REPARSE_TAG_MOUNT_POINT = 0xA0000003;
+	private const uint IO_REPARSE_TAG_SYMLINK = 0xA000000C;
 	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/b41f1cbf-10df-4a47-98d4-1c52a833d913
 	private enum SymlinkFlags : int {
 		 FullpathName = 0,
 		 SYMLINK_FLAG_RELATIVE = 1
+	}
+	public static bool IsValidSymlinkTag(uint tag) {
+		return tag == IO_REPARSE_TAG_SYMLINK || tag == IO_REPARSE_TAG_MOUNT_POINT;
 	}
 	internal string ParseSymlink(String originalPath) {
 		
@@ -65,7 +68,7 @@ public sealed class ReparsePoint
 
 		using var stream = new MemoryStream(reparsePoint.Content);
 		using var reader = new BinaryReader(stream);
-		if (reparsePoint.Tag != IO_REPARSE_TAG_SYMLINK && reparsePoint.Tag != IO_REPARSE_TAG_MOUNT_POINT)
+		if (! IsValidSymlinkTag(reparsePoint.Tag) )
 			throw new IOException($"Reparse point on {originalPath} is not a symlink or mount point (tag: 0x{reparsePoint.Tag:X8})");
 
 		var substNameOffset = reader.ReadUInt16();

--- a/Library/DiscUtils.Core/ReparsePoint.cs
+++ b/Library/DiscUtils.Core/ReparsePoint.cs
@@ -20,6 +20,10 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
+using System.IO;
+using System.Text;
+
 namespace DiscUtils;
 
 /// <summary>
@@ -47,4 +51,44 @@ public sealed class ReparsePoint
     /// Gets or sets the defined reparse point tag.
     /// </summary>
     public int Tag { get; set; }
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/c8e77b37-3909-4fe6-a4ea-2b9d423b1ee4
+	private const int IO_REPARSE_TAG_MOUNT_POINT = unchecked((int)0xA0000003);
+	private const int IO_REPARSE_TAG_SYMLINK = unchecked((int)0xA000000C);
+	// https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/b41f1cbf-10df-4a47-98d4-1c52a833d913
+	private enum SymlinkFlags : int {
+		 FullpathName = 0,
+		 SYMLINK_FLAG_RELATIVE = 1
+	}
+	internal string ParseSymlink(String originalPath) {
+		
+		var reparsePoint = this;
+
+		using var stream = new MemoryStream(reparsePoint.Content);
+		using var reader = new BinaryReader(stream);
+		if (reparsePoint.Tag != IO_REPARSE_TAG_SYMLINK && reparsePoint.Tag != IO_REPARSE_TAG_MOUNT_POINT)
+			throw new IOException($"Reparse point on {originalPath} is not a symlink or mount point (tag: 0x{reparsePoint.Tag:X8})");
+
+		var substNameOffset = reader.ReadUInt16();
+		var substNameLength = reader.ReadUInt16();
+		var printNameOffset = reader.ReadUInt16();
+		var printNameLength = reader.ReadUInt16();
+		SymlinkFlags? flags = null;
+		if (reparsePoint.Tag == IO_REPARSE_TAG_SYMLINK)
+			flags = (SymlinkFlags)reader.ReadUInt32();
+
+
+		string target;
+		// Prefer PrintName if available
+		if (printNameLength > 0) {
+			stream.Seek(printNameOffset, SeekOrigin.Current);
+			var pathBytes = reader.ReadBytes(printNameLength);
+			target = Encoding.Unicode.GetString(pathBytes);
+		} else {
+			stream.Seek(substNameOffset, SeekOrigin.Current);
+			var pathBytes = reader.ReadBytes(substNameLength);
+			target = Encoding.Unicode.GetString(pathBytes);
+			// alternatives I have done additional cleaning but for here we may want raw values: https://github.com/mitchcapper/gnulib/blob/b5c3b1b1f1fe6225363cddd72310e1fe95312466/lib/readlink.c#L115-#L182 but the use case here may be a bit different
+		}
+		return target;
+	}
 }

--- a/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
+++ b/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace DiscUtils.Vfs;
+
+internal class FullFile(VfsDirEntry DirEntry, IVfsFile File) : IAbstractRecord {
+	public DateTime CreationTimeUtc => File.CreationTimeUtc;
+	public FileAttributes FileAttributes => File.FileAttributes;
+	public string FileName => DirEntry.FileName;
+	public bool IsDirectory => DirEntry.IsDirectory;
+	public bool IsSymlink => DirEntry.IsSymlink;
+	public DateTime LastAccessTimeUtc => File.LastAccessTimeUtc;
+	public DateTime LastWriteTimeUtc => File.LastWriteTimeUtc;
+	public long FileId => DirEntry.UniqueCacheId;
+	public long FileSize => File.FileLength;
+	public Streams.IBuffer FileContent => File.FileContent;
+
+	public IAbstractDirectory GetAsAbstractDirectory() {
+		if (! IsDirectory) 
+			throw new InvalidOperationException("Not a directory");
+		if (this is IAbstractDirectory dir)
+			return dir;
+		throw new InvalidOperationException("We are not an instance of a directory but should be");
+	}
+	public VfsDirEntry GetAsDirEntry() => DirEntry;
+	public IVfsFile GetAsFile() => File;
+
+
+}
+public interface IAbstractRecord {
+		DateTime CreationTimeUtc { get; }
+		FileAttributes FileAttributes { get; }
+		string FileName { get; }
+		bool IsDirectory { get; }
+		bool IsSymlink { get; }
+		DateTime LastAccessTimeUtc { get; }
+		DateTime LastWriteTimeUtc { get; }
+		long FileId { get; }
+		long FileSize { get; }
+		Streams.IBuffer FileContent { get; }
+		VfsDirEntry GetAsDirEntry();
+		IVfsFile GetAsFile();
+		IAbstractDirectory GetAsAbstractDirectory();
+}
+
+public interface IAbstractDirectory : IAbstractRecord {
+		IEnumerable<IAbstractRecord> AllEntries { get; }
+}

--- a/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
+++ b/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
@@ -9,7 +9,7 @@ public interface IAbstractRecord {
 		DateTime CreationTimeUtc { get; }
 		FileAttributes FileAttributes { get; }
 	/// <summary>
-	/// the SubPath relative to the IAbstractDirectory that returned it
+	/// the SubPath relative to the parent IAbstractDirectory
 	/// </summary>
 		string FileName { get; }
 		bool IsDirectory { get; }

--- a/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
+++ b/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
@@ -8,6 +8,9 @@ namespace DiscUtils.Vfs;
 public interface IAbstractRecord {
 		DateTime CreationTimeUtc { get; }
 		FileAttributes FileAttributes { get; }
+	/// <summary>
+	/// the SubPath relative to the IAbstractDirectory that returned it
+	/// </summary>
 		string FileName { get; }
 		bool IsDirectory { get; }
 		bool IsSymlink { get; }

--- a/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
+++ b/Library/DiscUtils.Core/Vfs/IAbstractRecord.cs
@@ -1,34 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace DiscUtils.Vfs;
 
-internal class FullFile(VfsDirEntry DirEntry, IVfsFile File) : IAbstractRecord {
-	public DateTime CreationTimeUtc => File.CreationTimeUtc;
-	public FileAttributes FileAttributes => File.FileAttributes;
-	public string FileName => DirEntry.FileName;
-	public bool IsDirectory => DirEntry.IsDirectory;
-	public bool IsSymlink => DirEntry.IsSymlink;
-	public DateTime LastAccessTimeUtc => File.LastAccessTimeUtc;
-	public DateTime LastWriteTimeUtc => File.LastWriteTimeUtc;
-	public long FileId => DirEntry.UniqueCacheId;
-	public long FileSize => File.FileLength;
-	public Streams.IBuffer FileContent => File.FileContent;
 
-	public IAbstractDirectory GetAsAbstractDirectory() {
-		if (! IsDirectory) 
-			throw new InvalidOperationException("Not a directory");
-		if (this is IAbstractDirectory dir)
-			return dir;
-		throw new InvalidOperationException("We are not an instance of a directory but should be");
-	}
-	public VfsDirEntry GetAsDirEntry() => DirEntry;
-	public IVfsFile GetAsFile() => File;
-
-
-}
 public interface IAbstractRecord {
 		DateTime CreationTimeUtc { get; }
 		FileAttributes FileAttributes { get; }
@@ -39,7 +15,7 @@ public interface IAbstractRecord {
 		DateTime LastWriteTimeUtc { get; }
 		long FileId { get; }
 		long FileSize { get; }
-		Streams.IBuffer FileContent { get; }
+		Streams.SparseStream FileContent { get; }
 		VfsDirEntry GetAsDirEntry();
 		IVfsFile GetAsFile();
 		IAbstractDirectory GetAsAbstractDirectory();

--- a/Library/DiscUtils.Core/Vfs/VfsAbstractRecord.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsAbstractRecord.cs
@@ -1,0 +1,33 @@
+using DiscUtils.Streams;
+using DiscUtils.Vfs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DiscUtils.Vfs;
+
+public class VfsAbstractRecord(VfsDirEntry DirEntry, IVfsFile File) : IAbstractRecord {
+	public DateTime CreationTimeUtc => File.CreationTimeUtc;
+	public FileAttributes FileAttributes => File.FileAttributes;
+	public string FileName => DirEntry.FileName;
+	public bool IsDirectory => DirEntry.IsDirectory;
+	public bool IsSymlink => DirEntry.IsSymlink;
+	public DateTime LastAccessTimeUtc => File.LastAccessTimeUtc;
+	public DateTime LastWriteTimeUtc => File.LastWriteTimeUtc;
+	public long FileId => DirEntry.UniqueCacheId;
+	public long FileSize => File.FileLength;
+	public SparseStream FileContent => new BufferStream(File.FileContent, FileAccess.Read);
+
+	public IAbstractDirectory GetAsAbstractDirectory() {
+		if (! IsDirectory) 
+			throw new InvalidOperationException("Not a directory");
+		if (this is IAbstractDirectory dir)
+			return dir;
+		throw new InvalidOperationException("We are not an instance of a directory but should be");
+	}
+	public VfsDirEntry GetAsDirEntry() => DirEntry;
+	public IVfsFile GetAsFile() => File;
+}

--- a/Library/DiscUtils.Core/Vfs/VfsDirEntry.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsDirEntry.cs
@@ -37,6 +37,7 @@ namespace DiscUtils.Vfs;
 /// </remarks>
 public abstract class VfsDirEntry
 {
+		public static bool NO_SYMLINK_RESOLUTION;
     /// <summary>
     /// Gets the creation time of the file or directory.
     /// </summary>

--- a/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
@@ -655,6 +655,50 @@ public abstract class VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> : Di
         return file.FileLength;
     }
 
+	virtual protected IAbstractRecord GetAbstractRecord(TDirEntry dirEntry){
+		if (dirEntry.IsDirectory)
+			return new FullDirectory(this, dirEntry, ConvertDirEntryToDirectory(dirEntry));
+		else
+			return new FullFile(dirEntry, GetFile(dirEntry));
+	}
+	internal class FullDirectory(VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> fs, VfsDirEntry DirEntry, TDirectory Directory) : FullFile(DirEntry, Directory), IAbstractDirectory {
+		public IEnumerable<IAbstractRecord> AllEntries => Directory.AllEntries.Values.Select(fs.GetAbstractRecord);
+
+	}
+	private class FakeRootDirEntry(TDirectory rootDir, String rootPath) : VfsDirEntry {
+		public override DateTime CreationTimeUtc => rootDir.CreationTimeUtc;
+		public override FileAttributes FileAttributes => rootDir.FileAttributes;
+		public override string FileName => rootPath;
+		public override bool HasVfsFileAttributes => true;
+		public override bool HasVfsTimeInfo => true;
+		public override bool IsDirectory => true;
+		public override bool IsSymlink => false;
+		public override DateTime LastAccessTimeUtc => rootDir.LastAccessTimeUtc;
+		public override DateTime LastWriteTimeUtc => rootDir.LastWriteTimeUtc;
+		public override long UniqueCacheId => -1;
+	}
+	
+	//override string GetSymlinkTarget(
+	public override IAbstractRecord GetAbstractRecord(string path) {
+		if (IsRoot(path))
+        {
+			if (RootDirectory.Self == null){
+				return new FullDirectory(this, new FakeRootDirEntry(RootDirectory, path), RootDirectory);
+			}
+            return GetAbstractRecord(RootDirectory.Self);
+        }
+
+        if (path == null)
+        {
+            return default;
+        }
+
+        var dirEntry = GetDirectoryEntry(path)
+            ?? throw new FileNotFoundException("No such file or directory", path);
+		return GetAbstractRecord(dirEntry);
+	}
+
+
     protected TFile GetFile(TDirEntry dirEntry)
     {
         var cacheKey = dirEntry.UniqueCacheId;
@@ -755,6 +799,9 @@ public abstract class VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> : Di
 
         return GetFile(dirEntry);
     }
+
+
+	protected virtual TDirectory ConvertDirEntryToDirectory(TDirEntry dirEntry) => throw new NotImplementedException();
 
     /// <summary>
     /// Converts a directory entry to an object representing a file.
@@ -928,7 +975,20 @@ public abstract class VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> : Di
             }
         }
     }
-
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) {
+		if (! dirEntry.IsSymlink)
+			throw new ArgumentException(dirEntry.FileName + " is not a symlink");
+		var file = dirEntry.GetAsFile();
+		if (file is not IVfsSymlink<TDirEntry, TFile>) {
+			var dirEnt = dirEntry.GetAsDirEntry() as TDirEntry;
+			if (dirEnt == null)
+				throw new ArgumentException("Not a valid record for this filesystem");
+			file = GetFile(dirEnt);
+		}
+		if (file is not IVfsSymlink<TDirEntry, TFile> symlink)
+			throw new AccessViolationException($"Unknown Error: the directory entry says it is a symlink but unable to get as symlink");
+		return symlink.TargetPath;
+	}
     protected virtual (TDirEntry TargetEntry, string TargetPath) ResolveSymlink(TDirEntry entry, string path)
     {
         var currentEntry = entry;

--- a/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
@@ -801,7 +801,7 @@ public abstract class VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> : Di
     }
 
 
-	protected virtual TDirectory ConvertDirEntryToDirectory(TDirEntry dirEntry) => throw new NotImplementedException();
+	protected abstract TDirectory ConvertDirEntryToDirectory(TDirEntry dirEntry);// => throw new NotImplementedException();
 
     /// <summary>
     /// Converts a directory entry to an object representing a file.
@@ -997,7 +997,7 @@ public abstract class VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> : Di
         var resolvesLeft = 20;
         while (currentEntry.IsSymlink && resolvesLeft > 0)
         {
-            if (GetFile(currentEntry) is not IVfsSymlink<TDirEntry, TFile> symlink)
+            if (VfsDirEntry.NO_SYMLINK_RESOLUTION || GetFile(currentEntry) is not IVfsSymlink<TDirEntry, TFile> symlink)
             {
                 Trace.WriteLine($"Unable to resolve symlink '{path}'");
                 return default;

--- a/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
+++ b/Library/DiscUtils.Core/Vfs/VfsFileSystem.cs
@@ -659,9 +659,9 @@ public abstract class VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> : Di
 		if (dirEntry.IsDirectory)
 			return new FullDirectory(this, dirEntry, ConvertDirEntryToDirectory(dirEntry));
 		else
-			return new FullFile(dirEntry, GetFile(dirEntry));
+			return new VfsAbstractRecord(dirEntry, GetFile(dirEntry));
 	}
-	internal class FullDirectory(VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> fs, VfsDirEntry DirEntry, TDirectory Directory) : FullFile(DirEntry, Directory), IAbstractDirectory {
+	internal class FullDirectory(VfsFileSystem<TDirEntry, TFile, TDirectory, TContext> fs, VfsDirEntry DirEntry, TDirectory Directory) : VfsAbstractRecord(DirEntry, Directory), IAbstractDirectory {
 		public IEnumerable<IAbstractRecord> AllEntries => Directory.AllEntries.Values.Select(fs.GetAbstractRecord);
 
 	}

--- a/Library/DiscUtils.Ext/ExtFileSystem.cs
+++ b/Library/DiscUtils.Ext/ExtFileSystem.cs
@@ -108,4 +108,6 @@ public sealed class ExtFileSystem : VfsFileSystemFacade, IUnixFileSystem, IClust
 
         return superblock.Magic == SuperBlock.Ext2Magic;
     }
+	public override IAbstractRecord GetAbstractRecord(string path) => GetRealFileSystem<VfsExtFileSystem>().GetAbstractRecord(path);
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => GetRealFileSystem<VfsExtFileSystem>().GetSymlinkTarget(dirEntry);
 }

--- a/Library/DiscUtils.Ext/VfsExtFileSystem.cs
+++ b/Library/DiscUtils.Ext/VfsExtFileSystem.cs
@@ -154,7 +154,14 @@ internal sealed class VfsExtFileSystem : VfsReadOnlyFileSystem<DirEntry, File, D
         var file = GetFile(path);
         return file.EnumerateAllocationClusters();
     }
+	protected override Directory ConvertDirEntryToDirectory(DirEntry dirEntry) {
+		var inode = GetInode(dirEntry.Record.Inode);
+        if (dirEntry.Record.FileType != DirectoryRecord.FileTypeDirectory)
+			throw new Exception("Invalid Directory Request record is not a directory");
+        
+        return new Directory(Context, dirEntry.Record.Inode, inode);
 
+	}
     protected override File ConvertDirEntryToFile(DirEntry dirEntry)
     {
         var inode = GetInode(dirEntry.Record.Inode);

--- a/Library/DiscUtils.Fat/FatFileSystem.cs
+++ b/Library/DiscUtils.Fat/FatFileSystem.cs
@@ -29,6 +29,7 @@ using DiscUtils.CoreCompat;
 using DiscUtils.Internal;
 using DiscUtils.Streams;
 using DiscUtils.Streams.Compatibility;
+using DiscUtils.Vfs;
 using LTRData.Extensions.Split;
 
 namespace DiscUtils.Fat;
@@ -2109,6 +2110,53 @@ public sealed class FatFileSystem : DiscFileSystem, IDosFileSystem, IClusterBase
         stream.Position = pos;
         return new FatFileSystem(stream);
     }
+	internal class FatAbstractDirectory : FatAbstractRecord, IAbstractDirectory {
+		public FatAbstractDirectory(FatFileSystem fs, DirectoryEntry entry) : base(fs,entry) {
+			this.IsDirectory = true;
+		}
 
-#endregion
+		public IEnumerable<IAbstractRecord> AllEntries {
+			get{
+				var dir = fs.GetDirectory(FileName);
+				foreach (var di in dir.GetDirectories())
+					yield return new FatAbstractDirectory(fs,di);
+				foreach (var fi in dir.GetFiles())
+					yield return new FatAbstractRecord(fs,fi);
+			}
+		}
+	}
+	internal class FatAbstractRecord : IAbstractRecord {
+		protected FatFileSystem fs;
+		protected DirectoryEntry entry;
+
+		public FatAbstractRecord(FatFileSystem fs, DirectoryEntry entry) {
+			this.fs = fs;
+			this.entry  = entry;
+		}
+		public DateTime CreationTimeUtc => entry.CreationTime.ToUniversalTime();
+		public FileAttributes FileAttributes => IsDirectory ? FileAttributes.Directory :  (FileAttributes)entry.Attributes;
+		public string FileName => entry.Name.FullName;
+		public bool IsDirectory { get;protected set; }
+		public bool IsSymlink { get; } = false;
+		public DateTime LastAccessTimeUtc => entry.LastAccessTime.ToUniversalTime();
+		public DateTime LastWriteTimeUtc => entry.LastWriteTime.ToUniversalTime();
+		public long FileId => entry.FirstCluster;
+		public long FileSize => entry.FileSize;
+		public SparseStream FileContent => fs.OpenFile(FileName,FileMode.Open,FileAccess.Read);
+
+		public IAbstractDirectory GetAsAbstractDirectory() => this as IAbstractDirectory;
+		public VfsDirEntry GetAsDirEntry() => throw new NotImplementedException();
+		public IVfsFile GetAsFile() => throw new NotImplementedException();
+	}
+	public override IAbstractRecord GetAbstractRecord(string path) {
+		var dirEntry = GetDirectoryEntry(path)
+            ?? throw new FileNotFoundException("No such file", path);
+		if (dirEntry.Attributes.HasFlag(FatAttributes.Directory))
+			return new FatAbstractDirectory(this,dirEntry);
+		return new FatAbstractRecord(this,dirEntry);
+	}
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => null;
+
+	#endregion
 }
+

--- a/Library/DiscUtils.Fat/FatFileSystem.cs
+++ b/Library/DiscUtils.Fat/FatFileSystem.cs
@@ -2111,17 +2111,18 @@ public sealed class FatFileSystem : DiscFileSystem, IDosFileSystem, IClusterBase
         return new FatFileSystem(stream);
     }
 	internal class FatAbstractDirectory : FatAbstractRecord, IAbstractDirectory {
-		public FatAbstractDirectory(FatFileSystem fs, DirectoryEntry entry) : base(fs,entry) {
+		public FatAbstractDirectory(FatFileSystem fs, DirectoryEntry entry, String FullPath) : base(fs,entry,FullPath) {
 			this.IsDirectory = true;
 		}
+		public override string FileName => entry.Name.IsEndMarker() ? "" : entry.Name.FullName; //IsEndMarker is only true for us on the fake root dir, otherwise we would return nulls here.
 
 		public IEnumerable<IAbstractRecord> AllEntries {
 			get{
-				var dir = fs.GetDirectory(FileName);
+				var dir = fs.GetDirectory(FullPath);
 				foreach (var di in dir.GetDirectories())
-					yield return new FatAbstractDirectory(fs,di);
+					yield return new FatAbstractDirectory(fs,di,Path.Combine(FullPath,di.Name.FullName));
 				foreach (var fi in dir.GetFiles())
-					yield return new FatAbstractRecord(fs,fi);
+					yield return new FatAbstractRecord(fs,fi, Path.Combine(FullPath,fi.Name.FullName));
 			}
 		}
 	}
@@ -2129,31 +2130,38 @@ public sealed class FatFileSystem : DiscFileSystem, IDosFileSystem, IClusterBase
 		protected FatFileSystem fs;
 		protected DirectoryEntry entry;
 
-		public FatAbstractRecord(FatFileSystem fs, DirectoryEntry entry) {
+		public FatAbstractRecord(FatFileSystem fs, DirectoryEntry entry, String FullPath) {
 			this.fs = fs;
 			this.entry  = entry;
+			this.FullPath = FullPath;
 		}
 		public DateTime CreationTimeUtc => entry.CreationTime.ToUniversalTime();
 		public FileAttributes FileAttributes => IsDirectory ? FileAttributes.Directory :  (FileAttributes)entry.Attributes;
-		public string FileName => entry.Name.FullName;
-		public bool IsDirectory { get;protected set; }
+		public virtual string FileName => entry.Name.FullName;
+		protected string FullPath;
+		public bool IsDirectory { get; protected set; }
 		public bool IsSymlink { get; } = false;
 		public DateTime LastAccessTimeUtc => entry.LastAccessTime.ToUniversalTime();
 		public DateTime LastWriteTimeUtc => entry.LastWriteTime.ToUniversalTime();
 		public long FileId => entry.FirstCluster;
 		public long FileSize => entry.FileSize;
-		public SparseStream FileContent => fs.OpenFile(FileName,FileMode.Open,FileAccess.Read);
+		public SparseStream FileContent => fs.OpenFile(FullPath,FileMode.Open,FileAccess.Read);
 
 		public IAbstractDirectory GetAsAbstractDirectory() => this as IAbstractDirectory;
 		public VfsDirEntry GetAsDirEntry() => throw new NotImplementedException();
 		public IVfsFile GetAsFile() => throw new NotImplementedException();
 	}
 	public override IAbstractRecord GetAbstractRecord(string path) {
-		var dirEntry = GetDirectoryEntry(path)
-            ?? throw new FileNotFoundException("No such file", path);
+		var dirEntry = GetDirectoryEntry(path);
+		if (dirEntry == null && IsRootPath(path)){
+			var dir = GetDirectory(path);
+			dirEntry = dir.SelfEntry;//directory will create a fake one for us for root			
+		}
+		if (dirEntry == null)
+            throw new FileNotFoundException("No such file", path);
 		if (dirEntry.Attributes.HasFlag(FatAttributes.Directory))
-			return new FatAbstractDirectory(this,dirEntry);
-		return new FatAbstractRecord(this,dirEntry);
+			return new FatAbstractDirectory(this,dirEntry,path);
+		return new FatAbstractRecord(this,dirEntry,path);
 	}
 	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => null;
 

--- a/Library/DiscUtils.HfsPlus/HfsPlusFileSystem.cs
+++ b/Library/DiscUtils.HfsPlus/HfsPlusFileSystem.cs
@@ -49,7 +49,8 @@ public class HfsPlusFileSystem : VfsFileSystemFacade, IUnixFileSystem, IAllocati
     {
         return GetRealFileSystem<HfsPlusFileSystemImpl>().GetUnixFileInfo(path);
     }
-
+	public override IAbstractRecord GetAbstractRecord(string path) => GetRealFileSystem<HfsPlusFileSystemImpl>().GetAbstractRecord(path);
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => GetRealFileSystem<HfsPlusFileSystemImpl>().GetSymlinkTarget(dirEntry);
     internal static bool Detect(Stream stream)
     {
         if (stream.Length < 1536)

--- a/Library/DiscUtils.HfsPlus/HfsPlusFileSystemImpl.cs
+++ b/Library/DiscUtils.HfsPlus/HfsPlusFileSystemImpl.cs
@@ -119,10 +119,12 @@ internal sealed class HfsPlusFileSystemImpl : VfsFileSystem<DirEntry, File, Dire
         return fileBuffer.EnumerateAllocationExtents();
     }
 
-    /// <summary>
-    /// Size of the Filesystem in bytes
-    /// </summary>
-    public override long Size => throw new NotSupportedException("Filesystem size is not (yet) supported");
+	protected override Directory ConvertDirEntryToDirectory(DirEntry dirEntry) => ConvertDirEntryToFile(dirEntry) as Directory;
+
+	/// <summary>
+	/// Size of the Filesystem in bytes
+	/// </summary>
+	public override long Size => throw new NotSupportedException("Filesystem size is not (yet) supported");
 
     /// <summary>
     /// Used space of the Filesystem in bytes

--- a/Library/DiscUtils.Iso9660/CDReader.cs
+++ b/Library/DiscUtils.Iso9660/CDReader.cs
@@ -168,7 +168,8 @@ public class CDReader : VfsFileSystemFacade, IClusterBasedFileSystem,
     {
         return GetRealFileSystem<VfsCDReader>().GetUnixFileInfo(path);
     }
-
+	public override IAbstractRecord GetAbstractRecord(string path) => GetRealFileSystem<VfsCDReader>().GetAbstractRecord(path);
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => GetRealFileSystem<VfsCDReader>().GetSymlinkTarget(dirEntry);
     /// <summary>
     /// Detects if a stream contains a valid ISO file system.
     /// </summary>

--- a/Library/DiscUtils.Iso9660/VfsCDReader.cs
+++ b/Library/DiscUtils.Iso9660/VfsCDReader.cs
@@ -539,7 +539,13 @@ internal class VfsCDReader : VfsReadOnlyFileSystem<ReaderDirEntry, File, ReaderD
 
         throw new InvalidOperationException("No valid boot image");
     }
+	protected override ReaderDirectory ConvertDirEntryToDirectory(ReaderDirEntry dirEntry) {
+        if (dirEntry.IsDirectory)
+			throw new Exception("Invalid Directory Request record is not a directory");
+        
+        return new ReaderDirectory(Context, dirEntry);
 
+	}
     protected override File ConvertDirEntryToFile(ReaderDirEntry dirEntry)
     {
         if (dirEntry.IsDirectory)

--- a/Library/DiscUtils.Iso9660/VfsCDReader.cs
+++ b/Library/DiscUtils.Iso9660/VfsCDReader.cs
@@ -540,7 +540,7 @@ internal class VfsCDReader : VfsReadOnlyFileSystem<ReaderDirEntry, File, ReaderD
         throw new InvalidOperationException("No valid boot image");
     }
 	protected override ReaderDirectory ConvertDirEntryToDirectory(ReaderDirEntry dirEntry) {
-        if (dirEntry.IsDirectory)
+        if (! dirEntry.IsDirectory)
 			throw new Exception("Invalid Directory Request record is not a directory");
         
         return new ReaderDirectory(Context, dirEntry);

--- a/Library/DiscUtils.Nfs/NfsFileSystem.cs
+++ b/Library/DiscUtils.Nfs/NfsFileSystem.cs
@@ -26,6 +26,7 @@ using System.Collections.Generic;
 using System.IO;
 using DiscUtils.Internal;
 using DiscUtils.Streams;
+using DiscUtils.Vfs;
 using LTRData.Extensions.Buffers;
 
 namespace DiscUtils.Nfs;
@@ -829,4 +830,7 @@ public class NfsFileSystem : DiscFileSystem
 
         return handle;
     }
+
+	public override IAbstractRecord GetAbstractRecord(string path) => throw new NotImplementedException();
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => throw new NotImplementedException();
 }

--- a/Library/DiscUtils.Ntfs/Directory.cs
+++ b/Library/DiscUtils.Ntfs/Directory.cs
@@ -26,7 +26,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using DiscUtils.Internal;
-
+using DiscUtils.Vfs;
 using DirectoryIndexEntry =
     System.Collections.Generic.KeyValuePair<DiscUtils.Ntfs.FileNameRecord, DiscUtils.Ntfs.FileRecordReference>;
 
@@ -254,4 +254,14 @@ internal class Directory : File
             return _upperCase.Compare(_query, 0, _query.Length, buffer, 0x42, fnLen * 2);
         }
     }
+	internal class NtfsAbstractDirectory : NtfsAbstractRecord, IAbstractDirectory {
+		public NtfsAbstractDirectory(NtfsFileSystem fileSystem, FileNameRecord Record, FileRecordReference File, Directory Directory, String DirectoryPath) : base(fileSystem, Record, File,DirectoryPath) {
+			this.Directory = Directory;
+		}
+
+		public Directory Directory { get; }
+
+		IEnumerable<IAbstractRecord> IAbstractDirectory.AllEntries => Directory.Index.Entries.Where(FileSystem.FilterEntry).Select(entry => new NtfsAbstractRecord(this.FileSystem, entry.Key, entry.Value,Utilities.CombinePaths(this.FileName,entry.Key.FileName)));
+
+	}
 }

--- a/Library/DiscUtils.Ntfs/NtfsAbstractRecord.cs
+++ b/Library/DiscUtils.Ntfs/NtfsAbstractRecord.cs
@@ -14,9 +14,10 @@ internal class NtfsAbstractRecord(NtfsFileSystem fileSystem, FileNameRecord Reco
 
 	public DateTime CreationTimeUtc => Record.CreationTime;
 	public FileAttributes FileAttributes => Record.FileAttributes;
-	public string FileName => FilePath;
+	public string FileName => Record.FileName;
 	public bool IsDirectory => Record.Flags.HasFlag(NtfsFileAttributes.Directory);
-	public bool IsSymlink => Record.Flags.HasFlag(NtfsFileAttributes.ReparsePoint);
+	public bool IsSymlink => Record.Flags.HasFlag(NtfsFileAttributes.ReparsePoint) && ReparsePoint.IsValidSymlinkTag(Record.EASizeOrReparsePointTag);
+	
 	public DateTime LastAccessTimeUtc => Record.LastAccessTime;
 	public DateTime LastWriteTimeUtc => Record.ModificationTime;
 	public long FileId => (long)FileIndex.Value;
@@ -26,6 +27,7 @@ internal class NtfsAbstractRecord(NtfsFileSystem fileSystem, FileNameRecord Reco
 
 	protected NtfsFileSystem FileSystem { get; } = fileSystem;
 	protected FileNameRecord Record { get; } = Record;
+	public String FullPath => FilePath;
 	protected FileRecordReference FileIndex { get; } = FileIndex;
 	DateTime IVfsFile.CreationTimeUtc { get; set; }
 	FileAttributes IVfsFile.FileAttributes { get; set; }
@@ -35,7 +37,7 @@ internal class NtfsAbstractRecord(NtfsFileSystem fileSystem, FileNameRecord Reco
 	DateTime IVfsFile.LastWriteTimeUtc { get; set; }
 
 	public IAbstractDirectory GetAsAbstractDirectory() {
-
+		
 		if (!IsDirectory)
 			throw new InvalidOperationException("Not a directory");
 		var file = AsFile();

--- a/Library/DiscUtils.Ntfs/NtfsAbstractRecord.cs
+++ b/Library/DiscUtils.Ntfs/NtfsAbstractRecord.cs
@@ -1,0 +1,50 @@
+using DiscUtils.Streams;
+using DiscUtils.Vfs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DiscUtils.Ntfs;
+
+
+internal class NtfsAbstractRecord(NtfsFileSystem fileSystem, FileNameRecord Record, FileRecordReference FileIndex, String FilePath) : IAbstractRecord, IVfsFile {
+
+	public DateTime CreationTimeUtc => Record.CreationTime;
+	public FileAttributes FileAttributes => Record.FileAttributes;
+	public string FileName => FilePath;
+	public bool IsDirectory => Record.Flags.HasFlag(NtfsFileAttributes.Directory);
+	public bool IsSymlink => Record.Flags.HasFlag(NtfsFileAttributes.ReparsePoint);
+	public DateTime LastAccessTimeUtc => Record.LastAccessTime;
+	public DateTime LastWriteTimeUtc => Record.ModificationTime;
+	public long FileId => (long)FileIndex.Value;
+	public long FileSize => (long)Record.RealSize;
+	public File AsFile() => FileSystem.GetFile(FileIndex);
+	public SparseStream FileContent => AsFile().OpenStream(AttributeType.Data, default, FileAccess.Read); // AttributeType.Data  attributeName=null
+
+	protected NtfsFileSystem FileSystem { get; } = fileSystem;
+	protected FileNameRecord Record { get; } = Record;
+	protected FileRecordReference FileIndex { get; } = FileIndex;
+	DateTime IVfsFile.CreationTimeUtc { get; set; }
+	FileAttributes IVfsFile.FileAttributes { get; set; }
+	IBuffer IVfsFile.FileContent { get; }
+	long IVfsFile.FileLength { get; }
+	DateTime IVfsFile.LastAccessTimeUtc { get; set; }
+	DateTime IVfsFile.LastWriteTimeUtc { get; set; }
+
+	public IAbstractDirectory GetAsAbstractDirectory() {
+
+		if (!IsDirectory)
+			throw new InvalidOperationException("Not a directory");
+		var file = AsFile();
+		if (file is Directory d)
+			return new Directory.NtfsAbstractDirectory(FileSystem, Record, FileIndex, d,FilePath);
+		throw new InvalidOperationException("fileSystem.GetFile() should have returned us as a Directory but we were not");
+	}
+
+	public VfsDirEntry GetAsDirEntry() => throw new NotImplementedException();
+	public IVfsFile GetAsFile() => this;
+	IEnumerable<StreamExtent> IVfsFile.EnumerateAllocationExtents() => this.GetAsFile().EnumerateAllocationExtents();
+}

--- a/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
@@ -35,6 +35,8 @@ using DirectoryIndexEntry =
     System.Collections.Generic.KeyValuePair<DiscUtils.Ntfs.FileNameRecord, DiscUtils.Ntfs.FileRecordReference>;
 using System.Collections.Concurrent;
 using DiscUtils.Ntfs.Internals;
+using System.Text;
+using DiscUtils.Vfs;
 
 namespace DiscUtils.Ntfs;
 
@@ -2663,6 +2665,22 @@ public class NtfsFileSystem : DiscFileSystem, IClusterBasedFileSystem,
 
     public override uint VolumeId => (uint)_context.BiosParameterBlock.VolumeSerialNumber;
 
+	public override IAbstractRecord GetAbstractRecord(string path) {
+         var dirEntryPath = ParsePath(path, out _, out _);
+         var entry = GetDirectoryEntry(dirEntryPath);
+         return new NtfsAbstractRecord(this, entry.Value.Details, entry.Value.Reference, dirEntryPath);
+     }
+
+     public override string GetSymlinkTarget(IAbstractRecord dirEntry) {
+         if (!dirEntry.IsSymlink)
+             throw new ArgumentException($"dirEntry is not a symlink");
+
+         var reparsePoint = GetReparsePoint(dirEntry.FileName);
+         if (reparsePoint == null)
+             throw new IOException($"Unable to read reparse point for {dirEntry.FileName}");
+
+         return reparsePoint.ParseSymlink(dirEntry.FileName);
+     }
     /// <summary>
     /// A plugin system for handling reparse points. Handlers for specific tags can register here
     /// with a delegate that handles such reparse points when they are opened.

--- a/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
@@ -1426,7 +1426,7 @@ public class NtfsFileSystem : DiscFileSystem, IClusterBasedFileSystem,
 
                 using var contentStream = stream.Value.Open(FileAccess.Read);
                 var rp = contentStream.ReadStruct<ReparsePointRecord>((int)contentStream.Length);
-                return new ReparsePoint((int)rp.Tag, rp.Content);
+                return new ReparsePoint(rp.Tag, rp.Content);
             }
         }
 
@@ -2674,12 +2674,15 @@ public class NtfsFileSystem : DiscFileSystem, IClusterBasedFileSystem,
      public override string GetSymlinkTarget(IAbstractRecord dirEntry) {
          if (!dirEntry.IsSymlink)
              throw new ArgumentException($"dirEntry is not a symlink");
+		 if (dirEntry is not NtfsAbstractRecord ntfsDirEntry)
+			throw new ArgumentException($"dirEntry is not an NtfsAbstractRecord");
+		
 
-         var reparsePoint = GetReparsePoint(dirEntry.FileName);
+		var reparsePoint = GetReparsePoint(ntfsDirEntry.FullPath);
          if (reparsePoint == null)
-             throw new IOException($"Unable to read reparse point for {dirEntry.FileName}");
+             throw new IOException($"Unable to read reparse point for {ntfsDirEntry.FullPath}");
 
-         return reparsePoint.ParseSymlink(dirEntry.FileName);
+         return reparsePoint.ParseSymlink(ntfsDirEntry.FullPath);
      }
     /// <summary>
     /// A plugin system for handling reparse points. Handlers for specific tags can register here

--- a/Library/DiscUtils.SquashFs/SquashFileSystemReader.cs
+++ b/Library/DiscUtils.SquashFs/SquashFileSystemReader.cs
@@ -59,7 +59,8 @@ public class SquashFileSystemReader : VfsFileSystemFacade, IUnixFileSystem
     {
         return GetRealFileSystem<VfsSquashFileSystemReader>().GetUnixFileInfo(path);
     }
-
+	public override IAbstractRecord GetAbstractRecord(string path) => GetRealFileSystem<VfsSquashFileSystemReader>().GetAbstractRecord(path);
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => GetRealFileSystem<VfsSquashFileSystemReader>().GetSymlinkTarget(dirEntry);
     /// <summary>
     /// Detects if the stream contains a SquashFs file system.
     /// </summary>

--- a/Library/DiscUtils.SquashFs/VfsSquashFileSystemReader.cs
+++ b/Library/DiscUtils.SquashFs/VfsSquashFileSystemReader.cs
@@ -179,7 +179,15 @@ internal class VfsSquashFileSystemReader : VfsReadOnlyFileSystem<DirectoryEntry,
             _ => throw new NotSupportedException($"Unrecognized inode type: {inodeType}"),
         };
     }
+	protected override Directory ConvertDirEntryToDirectory(DirectoryEntry dirEntry) {
+        if (!dirEntry.IsDirectory)
+			throw new Exception("Invalid Directory Request record is not a directory");
+        var inodeRef = dirEntry.InodeReference;
+        _context.InodeReader.SetPosition(inodeRef);
+        var inode = Inode.Read(_context.InodeReader);
+        return new Directory(_context, inode, inodeRef);
 
+	}
     protected override File ConvertDirEntryToFile(DirectoryEntry dirEntry)
     {
         var inodeRef = dirEntry.InodeReference;

--- a/Library/DiscUtils.Swap/SwapFileSystem.cs
+++ b/Library/DiscUtils.Swap/SwapFileSystem.cs
@@ -21,6 +21,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using DiscUtils.Streams;
 using DiscUtils.Vfs;
@@ -108,4 +109,7 @@ public sealed class SwapFileSystem : VfsReadOnlyFileSystem<VfsDirEntry, IVfsFile
     {
         throw new NotImplementedException();
     }
+
+	
+	protected override IVfsDirectory<VfsDirEntry, IVfsFile> ConvertDirEntryToDirectory(VfsDirEntry dirEntry) => throw new NotImplementedException();
 }

--- a/Library/DiscUtils.Udf/UdfReader.cs
+++ b/Library/DiscUtils.Udf/UdfReader.cs
@@ -49,6 +49,8 @@ public sealed class UdfReader : VfsFileSystemFacade
     public UdfReader(Stream data, int sectorSize)
         : base(new VfsUdfReader(data, sectorSize)) {}
 
+	public override IAbstractRecord GetAbstractRecord(string path) => GetRealFileSystem<VfsUdfReader>().GetAbstractRecord(path);
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => GetRealFileSystem<VfsUdfReader>().GetSymlinkTarget(dirEntry);
     /// <summary>
     /// Detects if a stream contains a valid UDF file system.
     /// </summary>
@@ -309,5 +311,7 @@ public sealed class UdfReader : VfsFileSystemFacade
             return dt.TagIdentifier == TagIdentifier.AnchorVolumeDescriptorPointer
                    && dt.TagLocation == 256;
         }
-    }
+
+		protected override Directory ConvertDirEntryToDirectory(FileIdentifier dirEntry) => (Directory)File.FromDescriptor(Context, dirEntry.FileLocation);
+	}
 }

--- a/Library/DiscUtils.VirtualFileSystem/VirtualFileSystem.cs
+++ b/Library/DiscUtils.VirtualFileSystem/VirtualFileSystem.cs
@@ -6,6 +6,7 @@ using DiscUtils.Internal;
 using DiscUtils.Streams;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using DiscUtils.Vfs;
 
 namespace DiscUtils.VirtualFileSystem;
 public partial class VirtualFileSystem : DiscFileSystem, IWindowsFileSystem, IUnixFileSystem, IFileSystemBuilder
@@ -834,4 +835,6 @@ public partial class VirtualFileSystem : DiscFileSystem, IWindowsFileSystem, IUn
 
     void IFileSystemBuilder.AddFile(string name, string sourcePath, int ownerId, int groupId, UnixFilePermissions fileMode, DateTime modificationTime)
         => AddFile(name, sourcePath, ownerId, groupId, fileMode, UnixFileType.Regular, modificationTime, modificationTime, modificationTime);
+	public override string GetSymlinkTarget(IAbstractRecord record) => throw new NotImplementedException();
+	public override IAbstractRecord GetAbstractRecord(string path) => throw new NotImplementedException();
 }

--- a/Library/DiscUtils.Wim/WimFileSystem.cs
+++ b/Library/DiscUtils.Wim/WimFileSystem.cs
@@ -118,7 +118,7 @@ public class WimFileSystem : ReadOnlyDiscFileSystem, IWindowsFileSystem
 
         using var s = _file.OpenResourceStream(hdr);
         var buffer = s.ReadExactly((int)s.Length);
-        return new ReparsePoint((int)dirEntry.ReparseTag, buffer);
+        return new ReparsePoint(dirEntry.ReparseTag, buffer);
     }
 
     /// <summary>
@@ -750,14 +750,15 @@ public class WimFileSystem : ReadOnlyDiscFileSystem, IWindowsFileSystem
 	internal class WimAbstractRecord (WimFileSystem FileSystem, DirectoryEntry Record, String Path) : IAbstractRecord{
 		public DateTime CreationTimeUtc => DateTime.FromFileTimeUtc(Record.CreationTime); // Entry has creationTime
 		public FileAttributes FileAttributes => Record.Attributes;
-		public string FileName => Path;
+		public string FileName => Record.FileName;
+		public string FullPath => Path;
 		public bool IsDirectory => Record.Attributes.HasFlag(FileAttributes.Directory);
-		public bool IsSymlink  => Record.Attributes.HasFlag(FileAttributes.ReparsePoint);
+		public bool IsSymlink  => Record.Attributes.HasFlag(FileAttributes.ReparsePoint) && ReparsePoint.IsValidSymlinkTag(Record.ReparseTag);
 		public DateTime LastAccessTimeUtc => DateTime.FromFileTimeUtc(Record.LastAccessTime);
 		public DateTime LastWriteTimeUtc => DateTime.FromFileTimeUtc(Record.LastWriteTime);
 		public long FileId => BitConverter.ToInt64(Record.Hash, 0) ^ BitConverter.ToInt64(Record.Hash, 8) ^ BitConverter.ToInt32(Record.Hash, 16);
 		public long FileSize => FileSystem._file.LocateResource(Record.GetStreamHash(default))?.OriginalSize ?? 0;
-		public SparseStream FileContent => FileSystem.OpenFile(FileName, FileMode.Open, FileAccess.Read); 
+		public SparseStream FileContent => FileSystem.OpenFile(Path, FileMode.Open, FileAccess.Read); 
 		protected WimFileSystem FileSystem { get; } = FileSystem;
 		protected DirectoryEntry Record{ get; } = Record;
 
@@ -771,17 +772,19 @@ public class WimFileSystem : ReadOnlyDiscFileSystem, IWindowsFileSystem
 
 	}
 	private IAbstractRecord GetEntryAsAbstractRecord(DirectoryEntry record, String Path) => (record.Attributes.HasFlag(FileAttributes.Directory) && record.Attributes.HasFlag(FileAttributes.ReparsePoint) == false) ?
-			new WimAbstractDirectory(this,record,Path) :
-			new WimAbstractRecord(this,record,Path);
+			new WimAbstractDirectory(this,record, Path) :
+			new WimAbstractRecord(this,record, Path);
 	public override IAbstractRecord GetAbstractRecord(string path)=> GetEntryAsAbstractRecord(GetEntry(path),String.IsNullOrWhiteSpace(path) ? "/" : "");
 	public override string GetSymlinkTarget(IAbstractRecord dirEntry) {
 		if (!dirEntry.IsSymlink)
 			throw new ArgumentException($"dirEntry is not a symlink");
+		if (dirEntry is not WimAbstractRecord dirEntryWim)
+			throw new ArgumentException($"dirEntry is not a WimAbstractRecord");
 
-		var reparsePoint = GetReparsePoint(dirEntry.FileName);
+		var reparsePoint = GetReparsePoint(dirEntryWim.FullPath);
 		if (reparsePoint == null)
-			throw new IOException($"Unable to read reparse point for {dirEntry.FileName}");
+			throw new IOException($"Unable to read reparse point for {dirEntryWim.FullPath}");
 
-		return reparsePoint.ParseSymlink(dirEntry.FileName);
+		return reparsePoint.ParseSymlink(dirEntryWim.FullPath);
 	}
 }

--- a/Library/DiscUtils.Wim/WimFileSystem.cs
+++ b/Library/DiscUtils.Wim/WimFileSystem.cs
@@ -30,6 +30,7 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using System.Linq;
 using LTRData.Extensions.Split;
+using DiscUtils.Vfs;
 
 namespace DiscUtils.Wim;
 
@@ -109,8 +110,10 @@ public class WimFileSystem : ReadOnlyDiscFileSystem, IWindowsFileSystem
     public ReparsePoint GetReparsePoint(string path)
     {
         var dirEntry = GetEntry(path);
-
-        var hdr = _file.LocateResource(dirEntry.Hash)
+		var hash = dirEntry.Hash;
+		if (Utilities.IsAllZeros(hash))
+			hash = GetFileHash(path);
+        var hdr = _file.LocateResource(hash)
             ?? throw new IOException("No reparse point");
 
         using var s = _file.OpenResourceStream(hdr);
@@ -744,4 +747,41 @@ public class WimFileSystem : ReadOnlyDiscFileSystem, IWindowsFileSystem
             }
         }
     }
+	internal class WimAbstractRecord (WimFileSystem FileSystem, DirectoryEntry Record, String Path) : IAbstractRecord{
+		public DateTime CreationTimeUtc => DateTime.FromFileTimeUtc(Record.CreationTime); // Entry has creationTime
+		public FileAttributes FileAttributes => Record.Attributes;
+		public string FileName => Path;
+		public bool IsDirectory => Record.Attributes.HasFlag(FileAttributes.Directory);
+		public bool IsSymlink  => Record.Attributes.HasFlag(FileAttributes.ReparsePoint);
+		public DateTime LastAccessTimeUtc => DateTime.FromFileTimeUtc(Record.LastAccessTime);
+		public DateTime LastWriteTimeUtc => DateTime.FromFileTimeUtc(Record.LastWriteTime);
+		public long FileId => BitConverter.ToInt64(Record.Hash, 0) ^ BitConverter.ToInt64(Record.Hash, 8) ^ BitConverter.ToInt32(Record.Hash, 16);
+		public long FileSize => FileSystem._file.LocateResource(Record.GetStreamHash(default))?.OriginalSize ?? 0;
+		public SparseStream FileContent => FileSystem.OpenFile(FileName, FileMode.Open, FileAccess.Read); 
+		protected WimFileSystem FileSystem { get; } = FileSystem;
+		protected DirectoryEntry Record{ get; } = Record;
+
+		public IAbstractDirectory GetAsAbstractDirectory() => (IAbstractDirectory) this;
+		public VfsDirEntry GetAsDirEntry() => throw new NotImplementedException();
+		public IVfsFile GetAsFile() => throw new NotImplementedException();
+	}
+	internal class WimAbstractDirectory(WimFileSystem FileSystem, DirectoryEntry Record, String Path) : WimAbstractRecord(FileSystem, Record, Path), IAbstractDirectory {
+		public IEnumerable<IAbstractRecord> AllEntries => FileSystem.GetDirectory(this.Record.SubdirOffset).Select(record => FileSystem.GetEntryAsAbstractRecord(record,Utilities.CombinePaths(Path,record.FileName)));
+					
+
+	}
+	private IAbstractRecord GetEntryAsAbstractRecord(DirectoryEntry record, String Path) => (record.Attributes.HasFlag(FileAttributes.Directory) && record.Attributes.HasFlag(FileAttributes.ReparsePoint) == false) ?
+			new WimAbstractDirectory(this,record,Path) :
+			new WimAbstractRecord(this,record,Path);
+	public override IAbstractRecord GetAbstractRecord(string path)=> GetEntryAsAbstractRecord(GetEntry(path),String.IsNullOrWhiteSpace(path) ? "/" : "");
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) {
+		if (!dirEntry.IsSymlink)
+			throw new ArgumentException($"dirEntry is not a symlink");
+
+		var reparsePoint = GetReparsePoint(dirEntry.FileName);
+		if (reparsePoint == null)
+			throw new IOException($"Unable to read reparse point for {dirEntry.FileName}");
+
+		return reparsePoint.ParseSymlink(dirEntry.FileName);
+	}
 }

--- a/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
+++ b/Library/DiscUtils.Xfs/VfsXfsFileSystem.cs
@@ -203,4 +203,8 @@ internal sealed class VfsXfsFileSystem : VfsReadOnlyFileSystem<DirEntry, File, D
     {
         return 1 << (sb.SectorSizeLog2 - BBSHIFT);
     }
+
+	protected override Directory ConvertDirEntryToDirectory(DirEntry dirEntry) {
+		return dirEntry.CachedDirectory ??= new Directory(Context, dirEntry.Inode);
+	}
 }

--- a/Library/DiscUtils.Xfs/XfsFileSystem.cs
+++ b/Library/DiscUtils.Xfs/XfsFileSystem.cs
@@ -67,6 +67,8 @@ public sealed class XfsFileSystem : VfsFileSystemFacade, IUnixFileSystem, IAlloc
     {
         return GetRealFileSystem<VfsXfsFileSystem>().PathToExtents(path);
     }
+	public override IAbstractRecord GetAbstractRecord(string path) => GetRealFileSystem<VfsXfsFileSystem>().GetAbstractRecord(path);
+	public override string GetSymlinkTarget(IAbstractRecord dirEntry) => GetRealFileSystem<VfsXfsFileSystem>().GetSymlinkTarget(dirEntry);
 
     internal static bool Detect(Stream stream)
     {


### PR DESCRIPTION
This primarily exposes two new interfaces for files and directories:
```csharp
public interface IAbstractRecord {
		DateTime CreationTimeUtc { get; }
		FileAttributes FileAttributes { get; }
		string FileName { get; }
		bool IsDirectory { get; }
		bool IsSymlink { get; }
		DateTime LastAccessTimeUtc { get; }
		DateTime LastWriteTimeUtc { get; }
		long FileId { get; }
		long FileSize { get; }
		Streams.IBuffer FileContent { get; }
		VfsDirEntry GetAsDirEntry();
		IVfsFile GetAsFile();
		IAbstractDirectory GetAsAbstractDirectory();
}

public interface IAbstractDirectory : IAbstractRecord {
		IEnumerable<IAbstractRecord> AllEntries { get; }
}
```
and two methods on file systems:
```csharp
Vfs.IAbstractRecord GetAbstractRecord(string path);
string GetSymlinkTarget(Vfs.IAbstractRecord dirEntry);
```
First, thanks for continuing to develop such an awesome library :)  Secondly, while this PR I think brings some improvements (although at the cost of an additional interface) they are pretty minor at only 15% (given most wait is blocking IO that just gets cached in the current).  If this isn't desired it may be worth at least adding IsDirectory and IsSymlink to the requirements on DiscFile entries so those two bytes avoid string lookups.


My current primary use is to index my NAS that contains 20+ years of backups in all forms and formats just giving me a file name index of the files in it (and contained disk images and archives).  For DiscUtils if I find something it can open I just traverse from the root recursively through the drive to get every file/directory.  I have some sample code at the bottom.

My issue happened when I went to log the symlink target and noticed there wasn't a good way to do so. DiscFileSystemInfo doesn't provide a way to get the symlink target and neither does DiscFileSystem.  The clear choice was to cast to the actual concrete type and assume it has some way to do so, but before i went to try and condition switch on every possible format I looked further.  I started to run into the issues I documented in #39.

Vfs kind of looks like it does and seems to be used by almost everything except NTFS for some reason.  In addition there is no way to actually access VfsFileSystem as it primarily seems an internal only target.  You can get the VfsFileSystemFacade through casting for some file systems but not to the underlying wrapped item.

Next, as I started tracing how things worked I noticed there seemed to be some perceived inefficiency, at least in how I was use the library.  For each DiscFileInfo file I was calling .Attributes to check if it was a symlink (reparse point) but this did a full re-lookup of the file info based on its string path, a few conversions to File class and such even though the information was already had in the DirEntry we originally accessed.  I do see that many things were cached (although still the string file path was used as a key every time for many calls even though I was operating on a DiscFileInfo object).  I was actually surprised how fast it runs as it is very speedy at iterating systems.   I know you folks have used DiscUtils to mount images as live drives in Windows so I was curious to see how fast it was (although it could also use a severely different set of code paths potentially?) but I didn't have easy luck doing so.  I don't think your new image mounter: https://github.com/ArsenalRecon/Arsenal-Image-Mounter has an option in the free version to use DiscUtils (or the powershell / cli).  I think DiscUtilsDevio is still around for windows but uses an older copy of DiscUtils so my changes wouldn't have any effects there.    

Clearly though as people use it professionally it must be fast, but I wasn't seeing how to do that for my use case.

Still I figured it might be helpful to get a common interface for files that would work across file systems and support things like symlink resolution, directly knowing if something a symlink or a directory or a file,  and access to a "FileID".  Given both Windows and most *nix systems support a drive specific un-changing file ID I figured it would be helpful to expose.   For one it could avoid a recursion bug if you were to cache the ID's you already visited.  At the same time improve performance by allowing the user to have more "low level access" but still abstracted but able to get a folder and all its records.  I am bad at naming things so try to ignore that:)  This is also a bit hacky for one, I stuck this in Vfs but, NTFS doesn't use that so I still need to add it there.  There is also a real trashy hack around the DriveRoot as I need a DirEntry for my current implementation so in VfsFileSystem you will find "FakeRootDirEntry".  For one, this will return the wrong inode value for ext.

100% a draft but I figured it is at least a working example to get some feedback on in terms of interest.

Anyway at the end of the day, while I think it is more performant on a quick image test the improvements were pretty minor than I expected.  1m42s for the original traversing vs 1m27s for this code path.  It is only 15% faster.   Granted I did have to hard code disable symlink resolution on the old codepath to get it to complete but I doubt that really made a huge difference.
If user time is primarily the code itself though vs the system time a bit larger of a gap:
user    0m17.890s
sys     1m24.216s

user    0m4.181s
sys     1m23.801s




Here is my old style:

```csharp

int ExploreDir(DiscFileSystem fileSystem, string basePath, string currentPath) {
var dirInfo = fileSystem.GetDirectoryInfo(currentPath);
curDirLastWrite = dirInfo.LastWriteTimeUtc;
var directories = dirInfo.GetDirectories();
foreach (DiscDirectoryInfo directory in directories) {

				if (directory.Attributes.HasFlag(FileAttributes.ReparsePoint)) {
					callbacks.PrintSymLink(basePath + "/" + directory.FullName.Replace('\\', '/').TrimStart('/'),
						fileSystem.GetSymlinkTarget(fileSystem.GetAbstractRecord(directory.FullName)), directory.LastWriteTime);
					continue;
				}
				dirTotal += ExploreDir(fileSystem, basePath, directory.FullName);

}

var files = dirInfo.GetFiles();
foreach (var file in files) {
				var fullPath = basePath + "/" + file.FullName.Replace('\\', '/').TrimStart('/');
				if ((file.Attributes & FileAttributes.ReparsePoint) != 0) 
					callbacks.PrintSymLink(fullPath, fileSystem.GetSymlinkTarget(fileSystem.GetAbstractRecord(file.FullName)), file.LastWriteTime);
				else {
					callbacks.PrintItem(fullPath, file.LastWriteTime, file.Length);
					dirTotal += file.Length;
				}
}
}
```


Here the newer style:

```csharp
private long ExploreDir(DiscFileSystem fileSystem, string basePath, string currentPath,  IAbstractDirectory dir = null) 
var curDir = dir ?? fileSystem.GetAbstractRecord(currentPath) as IAbstractDirectory;
curDirLastWrite = curDir.LastWriteTimeUtc;
foreach (var record in curDir.AllEntries) {
				var recordFullPath = Path.Join(currentPath, record.FileName).Replace('\\', '/').TrimStart('/');
				if (record.IsSymlink)
					callbacks.PrintSymLink(basePath + "/" + recordFullPath, fileSystem.GetSymlinkTarget(record).Replace('\\', '/'), record.LastWriteTimeUtc);
				else if (record.IsDirectory) {
					dirTotal += PrintFolder(fileSystem, basePath, recordFullPath, record.GetAsAbstractDirectory());
				} else {
					var fullPath = basePath + "/" + recordFullPath.TrimStart('/');
					callbacks.PrintItem(fullPath, record.LastWriteTimeUtc, record.FileSize);
					dirTotal += record.FileSize;

				}
```




Finally (although unrelated), minor item, but it may be worth improving the generic VirtualDisk.OpenDisk docs about the fact passing it a file will only use the extension to determine possible compat decoders.   I maintain a list of my extensions that might be raw drives (say .bin or .iso if I was lazy) and then just call it with the forced "RAW" type if they fail to open automatically.
```csharp
disk = VirtualDisk.OpenDisk(file, FileAccess.Read);
if (disk.Partitions == null || disk.Partitions.Count == 0) {
				if (MayBeRawExtensions.Any(a => file.EndsWith(a, StringComparison.OrdinalIgnoreCase))) {
					disk.Dispose();
					disk = VirtualDisk.OpenDisk(file, "RAW", FileAccess.Read, default, default);
				}
}
