### PR TITLE
Ensure correct timezone is set on filetimes

### DIFF
--- a/Library/DiscUtils.Btrfs/Base/TimeSpec.cs
+++ b/Library/DiscUtils.Btrfs/Base/TimeSpec.cs
@@ -39,11 +39,11 @@ internal class TimeSpec : IByteArraySerializable
     /// </summary>
     public uint Nanoseconds { get; internal set; }
 
-    public DateTimeOffset Value => DateTimeOffset.FromUnixTimeSeconds(Seconds).AddTicks(Nanoseconds / 100);
+    public DateTimeOffset Value => DateTimeOffset.FromUnixTimeSeconds(Seconds).AddTicks(Nanoseconds / 100).UtcDateTime;
 
     public int Size => Length;
 
-    public DateTimeOffset DateTime => DateTimeOffset.FromUnixTimeSeconds(Seconds).AddTicks(Nanoseconds / 100);
+    public DateTimeOffset DateTime => DateTimeOffset.FromUnixTimeSeconds(Seconds).AddTicks(Nanoseconds / 100).UtcDateTime;
 
     public int ReadFrom(ReadOnlySpan<byte> buffer)
     {

--- a/Library/DiscUtils.Core/Archives/TarHeader.cs
+++ b/Library/DiscUtils.Core/Archives/TarHeader.cs
@@ -75,7 +75,7 @@ public sealed class TarHeader
         OwnerId = (int)OctalToLong(ReadNullTerminatedString(buffer.Slice(108, 8)));
         GroupId = (int)OctalToLong(ReadNullTerminatedString(buffer.Slice(116, 8)));
         FileLength = ParseFileLength(buffer.Slice(124, 12));
-        ModificationTime = DateTimeOffset.FromUnixTimeSeconds((uint)OctalToLong(ReadNullTerminatedString(buffer.Slice(136, 12))));
+        ModificationTime = DateTimeOffset.FromUnixTimeSeconds((uint)OctalToLong(ReadNullTerminatedString(buffer.Slice(136, 12)))).UtcDateTime;
         CheckSum = (int)OctalToLong(ReadNullTerminatedString(buffer.Slice(148, 8)));
         FileType = (TarFileType)buffer[156];
         LinkName = latin1Encoding.GetString(ReadNullTerminatedString(buffer.Slice(157, 100)));
@@ -93,8 +93,8 @@ public sealed class TarHeader
             FileName = $"{latin1Encoding.GetString(prefix)}/{FileName}";
         }
 
-        LastAccessTime = DateTimeOffset.FromUnixTimeSeconds((uint)OctalToLong(ReadNullTerminatedString(buffer.Slice(476, 12))));
-        CreationTime = DateTimeOffset.FromUnixTimeSeconds((uint)OctalToLong(ReadNullTerminatedString(buffer.Slice(488, 12))));
+        LastAccessTime = DateTimeOffset.FromUnixTimeSeconds((uint)OctalToLong(ReadNullTerminatedString(buffer.Slice(476, 12)))).UtcDateTime;
+        CreationTime = DateTimeOffset.FromUnixTimeSeconds((uint)OctalToLong(ReadNullTerminatedString(buffer.Slice(488, 12)))).UtcDateTime;
     }
 
     public static bool IsValid(ReadOnlySpan<byte> buffer)

--- a/Library/DiscUtils.Ext/File.cs
+++ b/Library/DiscUtils.Ext/File.cs
@@ -48,21 +48,21 @@ internal class File : IVfsFile
 
     public DateTime LastAccessTimeUtc
     {
-        get => DateTimeOffset.FromUnixTimeSeconds(Inode.AccessTime).DateTime;
+        get => DateTimeOffset.FromUnixTimeSeconds(Inode.AccessTime).UtcDateTime;
 
         set => throw new NotImplementedException();
     }
 
     public DateTime LastWriteTimeUtc
     {
-        get => DateTimeOffset.FromUnixTimeSeconds(Inode.ModificationTime).DateTime;
+        get => DateTimeOffset.FromUnixTimeSeconds(Inode.ModificationTime).UtcDateTime;
 
         set => throw new NotImplementedException();
     }
 
     public DateTime CreationTimeUtc
     {
-        get => DateTimeOffset.FromUnixTimeSeconds(Inode.CreationTime).DateTime;
+        get => DateTimeOffset.FromUnixTimeSeconds(Inode.CreationTime).UtcDateTime;
 
         set => throw new NotImplementedException();
     }

--- a/Library/DiscUtils.Lvm/Metadata.cs
+++ b/Library/DiscUtils.Lvm/Metadata.cs
@@ -128,7 +128,7 @@ internal class Metadata
             return DateTime.MaxValue;
         }
 
-        return DateTimeOffset.FromUnixTimeSeconds((long)numeric).DateTime;
+        return DateTimeOffset.FromUnixTimeSeconds((long)numeric).UtcDateTime;
     }
 
     internal static ulong ParseNumericValue(ReadOnlySpan<char> value)

--- a/Library/DiscUtils.SquashFs/Inode.cs
+++ b/Library/DiscUtils.SquashFs/Inode.cs
@@ -51,7 +51,7 @@ internal abstract class Inode : IByteArraySerializable
         Mode = EndianUtilities.ToUInt16LittleEndian(buffer.Slice(2));
         UidKey = EndianUtilities.ToUInt16LittleEndian(buffer.Slice(4));
         GidKey = EndianUtilities.ToUInt16LittleEndian(buffer.Slice(6));
-        ModificationTime = DateTimeOffset.FromUnixTimeSeconds(EndianUtilities.ToUInt32LittleEndian(buffer.Slice(8))).DateTime;
+        ModificationTime = DateTimeOffset.FromUnixTimeSeconds(EndianUtilities.ToUInt32LittleEndian(buffer.Slice(8))).UtcDateTime;
         InodeNumber = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(12));
         return 16;
     }

--- a/Library/DiscUtils.SquashFs/SuperBlock.cs
+++ b/Library/DiscUtils.SquashFs/SuperBlock.cs
@@ -78,7 +78,7 @@ internal class SuperBlock : IByteArraySerializable
         }
 
         InodesCount = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(4));
-        CreationTime = DateTimeOffset.FromUnixTimeSeconds(EndianUtilities.ToUInt32LittleEndian(buffer.Slice(8))).DateTime;
+        CreationTime = DateTimeOffset.FromUnixTimeSeconds(EndianUtilities.ToUInt32LittleEndian(buffer.Slice(8))).UtcDateTime;
         BlockSize = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(12));
         FragmentsCount = EndianUtilities.ToUInt32LittleEndian(buffer.Slice(16));
         Compression = (SquashFileSystemCompressionKind)EndianUtilities.ToUInt16LittleEndian(buffer.Slice(20));

--- a/Library/DiscUtils.Xfs/Inode.cs
+++ b/Library/DiscUtils.Xfs/Inode.cs
@@ -265,7 +265,7 @@ internal struct Inode : IByteArraySerializable
     {
         var seconds = EndianUtilities.ToUInt32BigEndian(buffer);
         var nanoSeconds = EndianUtilities.ToUInt32BigEndian(buffer.Slice(4));
-        return DateTimeOffset.FromUnixTimeSeconds(seconds).AddTicks(nanoSeconds / 100).LocalDateTime;
+        return DateTimeOffset.FromUnixTimeSeconds(seconds).AddTicks(nanoSeconds / 100).UtcDateTime;
     }
 
     void IByteArraySerializable.WriteTo(Span<byte> buffer)


### PR DESCRIPTION
Before the DateTime was unknown kind by default which meant if you called file.LastWriteTimeUtc.ToUniversalTime() it would give you a different time compared to file.LastWriteTImeUtc.   This isn't 'wrong' in theory as we say it is unknown and it is UTC time but as dotnet generally assumes localtime on unknown datetimes it might confuse the user.

The only one technically wrong was XFS which was implicitly getting the localtime.  I would also argue anywhere it got converted to a DateTimeOffset was also 'wrong' because when you convert an unspecified timezone DateTime to a DateTimeOffset it treats it as local and sets DateTimeOffset.Offset to the local offset.

