### PR TITLE
Fix distance calculation in SquashFS when block boundaries are exceeded

### DIFF
--- a/Library/DiscUtils.SquashFs/Directory.cs
+++ b/Library/DiscUtils.SquashFs/Directory.cs
@@ -54,7 +54,7 @@ internal class Directory : File, IVfsDirectory<DirectoryEntry, File>
                 var reader = Context.DirectoryReader;
                 reader.SetPosition(_dirInode.StartBlock, _dirInode.Offset);
 
-                // For some reason, always 3 greater than actual..
+                // The 3 additional bytes are for ".." and "."
                 while (reader.DistanceFrom(_dirInode.StartBlock, _dirInode.Offset) < _dirInode.FileSize - 3)
                 {
                     var header = DirectoryHeader.ReadFrom(reader);

--- a/Library/DiscUtils.SquashFs/MetablockReader.cs
+++ b/Library/DiscUtils.SquashFs/MetablockReader.cs
@@ -55,11 +55,57 @@ internal sealed class MetablockReader
         _currentBlockStart = blockStart;
         _currentOffset = blockOffset;
     }
-
+    
+    /// <summary>
+    /// Calculates the distance between the current position and the specified block position and offset.
+    /// </summary>
+    /// <remarks>
+    /// * BlockStart is always related to the start of the metablock in the raw data stream
+    /// * BlockOffset is the offset within the uncompressed data stream!
+    ///
+    /// This means, that there can never be a distance calculation based on start and offset
+    /// across block boundaries
+    ///
+    /// Therefor to calculate the distance across block boundaries we need to iteratively read
+    /// through all blocks from the starting block to the current block.
+    ///
+    /// In most (standard) cases everything will be within the same block and the calculation is trivial.
+    /// </remarks>
+    /// <param name="blockStart">The start of the metadatablock with the raw data</param>
+    /// <param name="blockOffset">The offset within the uncompressed block</param>
+    /// <returns>The distance between </returns>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
     public long DistanceFrom(long blockStart, int blockOffset)
     {
-        return (_currentBlockStart - blockStart) * VfsSquashFileSystemReader.MetadataBufferSize
-               + (_currentOffset - blockOffset);
+        if (blockStart > _currentBlockStart)
+        {
+            throw new ArgumentOutOfRangeException("Block start needs to be less than or equal to current block start");
+        }
+        
+        if (blockStart == _currentBlockStart)
+        {
+            return _currentOffset - blockOffset;
+        }
+        
+        var block = _context.ReadMetaBlock(_start + blockStart);
+        long distance = Metablock.SQUASHFS_METADATA_SIZE - blockOffset;
+        
+        do
+        {
+            block = _context.ReadMetaBlock(block.NextBlockStart);
+            blockStart = block.Position - _start;
+
+            if (blockStart == _currentBlockStart)
+            {
+                distance += _currentOffset;
+            }
+            else
+            {
+                distance += block.Data.LongLength;
+            }
+        } while (blockStart != _currentBlockStart);
+
+        return distance;
     }
 
     public void Skip(int count)

--- a/Library/DiscUtils.SquashFs/VfsSquashFileSystemReader.cs
+++ b/Library/DiscUtils.SquashFs/VfsSquashFileSystemReader.cs
@@ -35,6 +35,7 @@ internal class VfsSquashFileSystemReader : VfsReadOnlyFileSystem<DirectoryEntry,
     public override bool IsCaseSensitive => true;
 
     public const int MetadataBufferSize = 8 * 1024;
+    public const short BlockPrefixSize = 2;
     private readonly BlockCache<Block> _blockCache;
 
     private readonly Context _context;
@@ -272,7 +273,7 @@ internal class VfsSquashFileSystemReader : VfsReadOnlyFileSystem<DirectoryEntry,
         var stream = _context.RawStream;
         stream.Position = pos;
 
-        Span<byte> buffer = stackalloc byte[2];
+        Span<byte> buffer = stackalloc byte[BlockPrefixSize];
         stream.ReadExactly(buffer);
 
         int readLen = EndianUtilities.ToUInt16LittleEndian(buffer);
@@ -283,7 +284,7 @@ internal class VfsSquashFileSystemReader : VfsReadOnlyFileSystem<DirectoryEntry,
             readLen = Metablock.SQUASHFS_COMPRESSED_BIT;
         }
 
-        block.NextBlockStart = pos + readLen + 2;
+        block.NextBlockStart = pos + BlockPrefixSize + readLen;
 
         if (isCompressed)
         {


### PR DESCRIPTION
As stated in the documentation `Inodes are packed into the metadata blocks, and are not aligned to block boundaries, therefore inodes overlap compressed blocks` it is possible, that metadata blocks are not within the data block.

The code in general accounts for this situation. However the distance calculation worked with incorrect assumptions in regards to this.

This leads to situations, where for example directory metadata blocks could not be calculated correctly, when the metadata spans across multiple data blocks.

While debugging the problem, I added two very minimal changes to make things a little more clear in other areas.

These are the two different documentations which I used while debugging and fixing the problem:
* https://docs.kernel.org/filesystems/squashfs.html
* https://dr-emann.github.io/squashfs/ (This specifically is very good)