### PR TITLE
Update create directory to clear cluster when directory is created

### DIFF
--- a/Library/DiscUtils.Fat/Directory.cs
+++ b/Library/DiscUtils.Fat/Directory.cs
@@ -532,6 +532,15 @@ internal class Directory : IDisposable
         // Populate new directory with initial (special) entries.  First one is easy, just change the name!
         using var stream = new ClusterStream(FileSystem, FileAccess.Write, newEntry.FirstCluster,
                 uint.MaxValue);
+
+        // Clear cluster with zeroes in case it contains existing data from quick formatting
+        var blankCluster = new byte[FileSystem.ClusterSize];
+        for (var cluster = 0; cluster < stream.Length / FileSystem.ClusterSize; cluster++)
+        {
+            stream.Write(blankCluster);
+        }
+        stream.Position = 0;
+
         // First is the self-referencing entry...
         var selfEntry = new DirectoryEntry(newEntry, FatFileName.SelfEntryName);
         selfEntry.WriteTo(stream, FileSystem.FatOptions.FileNameEncodingTable);

--- a/Tests/LibraryTests/Fat/FatFileSystemTest.cs
+++ b/Tests/LibraryTests/Fat/FatFileSystemTest.cs
@@ -582,4 +582,31 @@ public class FatFileSystemTest
 
         Assert.True(pattern.SequenceEqual(buffer));
     }
+
+    [Fact]
+    public void CreateDirectoryWithExistingData()
+    {
+        const int highDensitySize = 1474560;
+        using var diskStream = new SparseMemoryStream();
+
+        byte[] existingData = [
+            0x00, 0x00, 0x00, 0x4E, 0x00, 0x0A, 0x7B, 0x9B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
+            0x00, 0x0A, 0x7B, 0xE9, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x0A, 0x7B, 0xEB,
+        ];
+
+        for (var i = 0; i < 1474560 / existingData.Length; i++)
+        {
+            diskStream.Seek(i * existingData.Length, SeekOrigin.Begin);
+            diskStream.Write(existingData, 0, existingData.Length);
+        }
+
+        diskStream.Position = 0;
+        using var fs = FatFileSystem.FormatFloppy(diskStream, FloppyDiskType.HighDensity, "FLOPPY_IMG ");
+
+        fs.CreateDirectory("dir");
+
+        var entries = fs.GetFileSystemEntries("dir").ToList();
+
+        Assert.Empty(entries);
+    }
 }


### PR DESCRIPTION
I have been using DiscUtils for many years with great success and I have recently experienced an issue with fat filesystem library where creating a new directory in root directory of a FAT32 formatted partition would contain existing directories and files with garbled filename characters.

After a lot of testing, I discovered the reason for the newly created directory already contained directories and files with garbled filename characters was caused by clusters contained data from a non-valid FAT32 filesystem structure, which are interpreted as directories and files by DiscUtils fat file system library.

I examined FAT32 clusters when Windows 11 creates a new directory and a file within the directory and noticed that Windows had cleared the cluster with zeroes before creating the cluster for the directory content.

I propose a change to `PopulateNewChildDirectory` that clears the cluster with zeroes before creating the self and parent referencing directory entries. I also added a test that was first used to verify the issue with existing data can cause a newly created directory to contain existing directories and files with garbled filenames and afterwards use it to fix the issue and verify it works.