### PR TITLE
Fix fat load entries update end of entries when cluster doesnt contain end marker entry

### DIFF
--- a/Library/DiscUtils.Fat/Directory.cs
+++ b/Library/DiscUtils.Fat/Directory.cs
@@ -471,6 +471,8 @@ internal class Directory : IDisposable
             {
                 AddEntryRaw(streamPos, entry);
             }
+
+            _endOfEntries = _dirStream.Position;
         }
 
         // Record any pending free entry

--- a/Tests/LibraryTests/Fat/FatFileSystemTest.cs
+++ b/Tests/LibraryTests/Fat/FatFileSystemTest.cs
@@ -608,4 +608,72 @@ public class FatFileSystemTest
 
         Assert.Empty(entries);
     }
+
+    [Fact]
+    public void CreateFilesInSubdirectoryUsingFatFileSystemPerFile()
+    {
+        using var diskStream = new SparseMemoryStream();
+
+        diskStream.Position = 0;
+        using (var fsFormat = FatFileSystem.FormatFloppy(diskStream, FloppyDiskType.HighDensity, "FLOPPY_IMG "))
+        {
+            fsFormat.CreateDirectory("dir");            
+        }
+
+        for (var i = 0; i < 20; i++)
+        {
+            using (var fsCreate = new FatFileSystem(diskStream))
+            {
+                using (var fileStream = fsCreate.OpenFile($"dir{Path.DirectorySeparatorChar}file{i}.txt", FileMode.Create))
+                {
+                    fileStream.Write(new byte[10]);
+                }
+            }            
+        }
+
+        using var fsAssert = new FatFileSystem(diskStream);
+        {
+            var entries = fsAssert.GetFileSystemEntries("").ToList();
+            Assert.Single(entries);
+            Assert.Equal("dir", entries[0]);
+
+            entries = fsAssert.GetFileSystemEntries("dir").ToList();
+            Assert.Equal(20, entries.Count);
+            Assert.Equal(Enumerable.Range(0, 20).Select(i => $"dir\\file{i}.txt"), entries);
+        }
+    }
+
+    [Fact]
+    public void CreateFilesInSubdirectoryUsingOneFatFileSystem()
+    {
+        using var diskStream = new SparseMemoryStream();
+
+        diskStream.Position = 0;
+        using (var fsFormat = FatFileSystem.FormatFloppy(diskStream, FloppyDiskType.HighDensity, "FLOPPY_IMG "))
+        {
+            fsFormat.CreateDirectory("dir");            
+        }
+
+        using (var fsCreate = new FatFileSystem(diskStream))
+        {
+            for (var i = 0; i < 20; i++)
+            {
+                using (var fileStream = fsCreate.OpenFile($"dir{Path.DirectorySeparatorChar}file{i}.txt", FileMode.Create))
+                {
+                    fileStream.Write(new byte[10]);
+                }
+            }            
+        }
+
+        using var fsAssert = new FatFileSystem(diskStream);
+        {
+            var entries = fsAssert.GetFileSystemEntries("").ToList();
+            Assert.Single(entries);
+            Assert.Equal("dir", entries[0]);
+
+            entries = fsAssert.GetFileSystemEntries("dir").ToList();
+            Assert.Equal(20, entries.Count);
+            Assert.Equal(Enumerable.Range(0, 20).Select(i => $"dir\\file{i}.txt"), entries);
+        }
+    }
 }


### PR DESCRIPTION
This PR fixes an issue with FAT partition when creating 20 files in a subdirectory where each file is created with a new instance of FatFileSystem. 

This results in the exception `An item with the same key has already been added` when the subdirectory contains 16 entries with a FAT formatted floppy using a cluster size of 512 bytes. The 16 entries consists of a self entry, a parent entry and 14 file entries, each with the size of 32 bytes and in total 32 * 16 = 512 bytes.

When the FatFileSystem loads directory entries, it creates an internal dictionary with entry position as key (used for fast lookup) from the position in of the entry in the cluster and that method only sets next entry position (`_endOfEntries` variable) when it reaches an entry with end marker name / end of cluster. The next entry position is used when new entries are added and since it's not updated after loading directory entries, it will start from 0 cause entries to be overwritten and this is why the exception `An item with the same key has already been added` is thrown. This is also why no new cluster is allocated for the new entry that should have been added to the end of entries in the cluster.

To fix the issue, I have added a line at the end of the while loop that loads entries from a directory to ensure `_endOfEntries` variable is always set to the next entry position. The variable is still updated, if end marker entry is reached.

Two tests was added used to compare the difference between creating one FatFileSystem instance used to create 20 files and creating a FatFileSystem instance for each file to create.