### PR TITLE
iSCSI: Add NOP-Out keepalive and handle target-initiated NOP-In

### DIFF
--- a/Library/DiscUtils.Iscsi/Connection.cs
+++ b/Library/DiscUtils.Iscsi/Connection.cs
@@ -46,6 +46,17 @@ internal sealed class Connection : IDisposable
 
     private readonly NetworkStream _stream;
 
+    /// <summary>
+    /// Semaphore to synchronize access to the network stream. NOP-Out responses from the
+    /// keepalive timer and normal Send/ReadPdu traffic must not interleave.
+    /// </summary>
+    private readonly SemaphoreSlim _streamSemaphore = new(1, 1);
+
+    /// <summary>
+    /// Timer that periodically sends NOP-Out pings to keep the iSCSI session alive.
+    /// </summary>
+    private Timer _keepAliveTimer;
+
     public Connection(Session session, TargetAddress address, Authenticator[] authenticators)
     {
         Session = session;
@@ -80,6 +91,11 @@ internal sealed class Connection : IDisposable
         _negotiatedParameters = [];
         NegotiateSecurity();
         NegotiateFeatures();
+
+        // Start keepalive timer after login completes.
+        // Send a NOP-Out every 10 seconds to prevent the target from
+        // timing out the session during idle periods.
+        _keepAliveTimer = new Timer(KeepAliveCallback, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
     }
 
     internal LoginStages CurrentLoginStage { get; private set; } = LoginStages.SecurityNegotiation;
@@ -106,17 +122,30 @@ internal sealed class Connection : IDisposable
     {
         try
         {
-            var req = new LogoutRequest(this);
-            var packet = req.GetBytes(reason);
-            _stream.Write(packet, 0, packet.Length);
-            _stream.Flush();
-
-            var pdu = ReadPdu();
-            var resp = ParseResponse<LogoutResponse>(pdu);
-
-            if (resp.Response != LogoutResponseCode.ClosedSuccessfully)
+            _streamSemaphore.Wait();
+            try
             {
-                throw new InvalidProtocolException($"Target indicated failure during logout: {resp.Response}");
+                // Stop the keepalive timer while holding the semaphore
+                // to ensure no callback is in-flight.
+                _keepAliveTimer?.Dispose();
+                _keepAliveTimer = null;
+
+                var req = new LogoutRequest(this);
+                var packet = req.GetBytes(reason);
+                _stream.Write(packet, 0, packet.Length);
+                _stream.Flush();
+
+                var pdu = ReadPdu();
+                var resp = ParseResponse<LogoutResponse>(pdu);
+
+                if (resp.Response != LogoutResponseCode.ClosedSuccessfully)
+                {
+                    throw new InvalidProtocolException($"Target indicated failure during logout: {resp.Response}");
+                }
+            }
+            finally
+            {
+                _streamSemaphore.Release();
             }
         }
         catch (EndOfStreamException)
@@ -134,6 +163,61 @@ internal sealed class Connection : IDisposable
     }
 
     /// <summary>
+    /// Timer callback: sends a NOP-Out to keep the iSCSI session alive.
+    /// Uses ITT=0xFFFFFFFF and TTT=0xFFFFFFFF so the target does not send a NOP-In response
+    /// (RFC 3720 §10.18), avoiding read-side contention with the main Send path.
+    /// </summary>
+    private void KeepAliveCallback(object state)
+    {
+        if (!_streamSemaphore.Wait(0))
+        {
+            // A Send or Close is in progress; skip this ping and retry on the next timer tick.
+            return;
+        }
+
+        try
+        {
+            SendNopOut();
+        }
+        catch (IOException)
+        {
+            // Connection is dead — the next Send will surface the error.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Stream was disposed — connection is shutting down.
+        }
+        finally
+        {
+            _streamSemaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Sends an initiator-initiated NOP-Out with ITT=0xFFFFFFFF and TTT=0xFFFFFFFF.
+    /// This is a "ping" that keeps the iSCSI session alive without requiring a response.
+    /// </summary>
+    private void SendNopOut()
+    {
+        var nopOut = new byte[48];
+        // Byte 0: Immediate (0x40) | OpCode NopOut (0x00)
+        nopOut[0] = 0x40;
+        // Byte 1: Final bit
+        nopOut[1] = 0x80;
+        // Bytes 16-19: ITT = 0xFFFFFFFF (no response expected)
+        EndianUtilities.WriteBytesBigEndian(0xFFFFFFFF, nopOut, 16);
+        // Bytes 20-23: TTT = 0xFFFFFFFF
+        EndianUtilities.WriteBytesBigEndian(0xFFFFFFFF, nopOut, 20);
+        // Bytes 24-27: CmdSN (not incremented for immediate PDUs)
+        EndianUtilities.WriteBytesBigEndian(Session.CommandSequenceNumber, nopOut, 24);
+        // Bytes 28-31: ExpStatSN
+        EndianUtilities.WriteBytesBigEndian(ExpectedStatusSequenceNumber, nopOut, 28);
+
+        _stream.Write(nopOut, 0, nopOut.Length);
+        _stream.Flush();
+    }
+
+    /// <summary>
     /// Sends an SCSI command (aka task) to a LUN via the connected target.
     /// </summary>
     /// <param name="cmd">The command to send.</param>
@@ -142,6 +226,9 @@ internal sealed class Connection : IDisposable
     /// <returns>The number of bytes received.</returns>
     public int Send(ScsiCommand cmd, ReadOnlySpan<byte> outBuffer, Span<byte> inBuffer)
     {
+        _streamSemaphore.Wait();
+        try
+        {
         for (var i = 0; ; i++)
         {
             try
@@ -281,6 +368,11 @@ internal sealed class Connection : IDisposable
             {
             }
         }
+        }
+        finally
+        {
+            _streamSemaphore.Release();
+        }
     }
 
     /// <summary>
@@ -293,6 +385,9 @@ internal sealed class Connection : IDisposable
     /// <returns>The number of bytes received.</returns>
     public async ValueTask<int> SendAsync(ScsiCommand cmd, ReadOnlyMemory<byte> outBuffer, Memory<byte> inBuffer, CancellationToken cancellationToken)
     {
+        await _streamSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
         for (var i = 0; ; i++)
         {
             try
@@ -409,6 +504,11 @@ internal sealed class Connection : IDisposable
             retry:
             {
             }
+        }
+        }
+        finally
+        {
+            _streamSemaphore.Release();
         }
     }
 
@@ -816,32 +916,115 @@ internal sealed class Connection : IDisposable
 
     private ProtocolDataUnit ReadPdu()
     {
-        var pdu = ProtocolDataUnit.ReadFrom(_stream, HeaderDigest != Digest.None, DataDigest != Digest.None);
-
-        if (pdu.OpCode == OpCode.Reject)
+        const int MaxNopInRetries = 16;
+        for (var nopCount = 0; ; nopCount++)
         {
-            var pkt = new RejectPacket();
-            pkt.Parse(pdu);
+            var pdu = ProtocolDataUnit.ReadFrom(_stream, HeaderDigest != Digest.None, DataDigest != Digest.None);
 
-            throw new IscsiException($"Target sent reject packet, reason {pkt.Reason}");
+            if (pdu.OpCode == OpCode.Reject)
+            {
+                var pkt = new RejectPacket();
+                pkt.Parse(pdu);
+
+                throw new IscsiException($"Target sent reject packet, reason {pkt.Reason}");
+            }
+
+            // RFC 3720 §10.19: Handle target-initiated NOP-In (ping).
+            // Respond with NOP-Out echoing the Target Transfer Tag, then
+            // continue reading the next PDU.
+            if (pdu.OpCode == OpCode.NopIn)
+            {
+                if (nopCount >= MaxNopInRetries)
+                {
+                    throw new InvalidProtocolException($"Received {nopCount} consecutive NOP-In PDUs without a command response");
+                }
+
+                HandleNopIn(pdu);
+                continue;
+            }
+
+            return pdu;
         }
-
-        return pdu;
     }
 
     private async ValueTask<ProtocolDataUnit> ReadPduAsync(CancellationToken cancellationToken)
     {
-        var pdu = await ProtocolDataUnit.ReadFromAsync(_stream, HeaderDigest != Digest.None, DataDigest != Digest.None, cancellationToken).ConfigureAwait(false);
-
-        if (pdu.OpCode == OpCode.Reject)
+        const int MaxNopInRetries = 16;
+        for (var nopCount = 0; ; nopCount++)
         {
-            var pkt = new RejectPacket();
-            pkt.Parse(pdu);
+            var pdu = await ProtocolDataUnit.ReadFromAsync(_stream, HeaderDigest != Digest.None, DataDigest != Digest.None, cancellationToken).ConfigureAwait(false);
 
-            throw new IscsiException($"Target sent reject packet, reason {pkt.Reason}");
+            if (pdu.OpCode == OpCode.Reject)
+            {
+                var pkt = new RejectPacket();
+                pkt.Parse(pdu);
+
+                throw new IscsiException($"Target sent reject packet, reason {pkt.Reason}");
+            }
+
+            if (pdu.OpCode == OpCode.NopIn)
+            {
+                if (nopCount >= MaxNopInRetries)
+                {
+                    throw new InvalidProtocolException($"Received {nopCount} consecutive NOP-In PDUs without a command response");
+                }
+
+                HandleNopIn(pdu);
+                continue;
+            }
+
+            return pdu;
+        }
+    }
+
+    /// <summary>
+    /// Responds to a target-initiated NOP-In with a NOP-Out (RFC 3720 §10.18/10.19).
+    /// Target-initiated NOP-In has TTT != 0xFFFFFFFF and requires a NOP-Out reply.
+    /// The StatSN in a target-initiated NOP-In is informational and does NOT consume
+    /// a sequence number, so we must NOT call SeenStatusSequenceNumber here.
+    /// </summary>
+    private void HandleNopIn(ProtocolDataUnit pdu)
+    {
+        var headerData = pdu.HeaderData;
+
+        // Target Transfer Tag at offset 20
+        var targetTransferTag = EndianUtilities.ToUInt32BigEndian(headerData.AsSpan(20));
+
+        // If TTT is 0xFFFFFFFF, this is a response to our own NOP-Out (unsolicited);
+        // no reply needed.
+        if (targetTransferTag == 0xFFFFFFFF)
+        {
+            return;
         }
 
-        return pdu;
+        // LUN at offset 8
+        var lun = EndianUtilities.ToUInt64BigEndian(headerData.AsSpan(8));
+
+        // NOTE: We intentionally do NOT call SeenStatusSequenceNumber() here.
+        // RFC 3720 §10.19: A target-initiated NOP-In carries a StatSN, but this
+        // StatSN is NOT consumed — it's the same value the target will use for the
+        // next real command response. Advancing ExpectedStatusSequenceNumber here
+        // would cause the next ParseResponse to fail with a sequence mismatch.
+
+        // Build NOP-Out response (RFC 3720 §10.18)
+        var nopOut = new byte[48];
+        // Byte 0: Immediate bit (0x40) | OpCode NopOut (0x00)
+        nopOut[0] = 0x40;
+        // Byte 1: Final bit (0x80)
+        nopOut[1] = 0x80;
+        // Bytes 8-15: LUN (copy from NOP-In)
+        EndianUtilities.WriteBytesBigEndian(lun, nopOut, 8);
+        // Bytes 16-19: Initiator Task Tag = 0xFFFFFFFF (response to target ping)
+        EndianUtilities.WriteBytesBigEndian(0xFFFFFFFF, nopOut, 16);
+        // Bytes 20-23: Target Transfer Tag (echo from NOP-In)
+        EndianUtilities.WriteBytesBigEndian(targetTransferTag, nopOut, 20);
+        // Bytes 24-27: CmdSN (not consumed for immediate PDUs with ITT=0xFFFFFFFF)
+        EndianUtilities.WriteBytesBigEndian(Session.CommandSequenceNumber, nopOut, 24);
+        // Bytes 28-31: ExpStatSN
+        EndianUtilities.WriteBytesBigEndian(ExpectedStatusSequenceNumber, nopOut, 28);
+
+        _stream.Write(nopOut, 0, nopOut.Length);
+        _stream.Flush();
     }
 
     private void GetParametersToNegotiate(TextBuffer parameters, KeyUsagePhase phase, SessionType sessionType)

--- a/Library/DiscUtils.Iscsi/Connection.cs
+++ b/Library/DiscUtils.Iscsi/Connection.cs
@@ -26,6 +26,7 @@ using LTRData.Extensions.Buffers;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Sockets;
@@ -95,7 +96,10 @@ internal sealed class Connection : IDisposable
         // Start keepalive timer after login completes.
         // Send a NOP-Out every 10 seconds to prevent the target from
         // timing out the session during idle periods.
-        _keepAliveTimer = new Timer(KeepAliveCallback, null, TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
+        _keepAliveTimer = new Timer(callback: KeepAliveCallback,
+                                    state: null,
+                                    dueTime: TimeSpan.FromSeconds(10),
+                                    period: TimeSpan.FromSeconds(10));
     }
 
     internal LoginStages CurrentLoginStage { get; private set; } = LoginStages.SecurityNegotiation;
@@ -167,7 +171,7 @@ internal sealed class Connection : IDisposable
     /// Uses ITT=0xFFFFFFFF and TTT=0xFFFFFFFF so the target does not send a NOP-In response
     /// (RFC 3720 §10.18), avoiding read-side contention with the main Send path.
     /// </summary>
-    private void KeepAliveCallback(object state)
+    private async void KeepAliveCallback(object _)
     {
         if (!_streamSemaphore.Wait(0))
         {
@@ -177,7 +181,11 @@ internal sealed class Connection : IDisposable
 
         try
         {
-            SendNopOut();
+#if DEBUG
+            Trace.WriteLine("Sending keep-alive...");
+#endif
+
+            await SendNopOutAsync().ConfigureAwait(false);
         }
         catch (IOException)
         {
@@ -193,28 +201,36 @@ internal sealed class Connection : IDisposable
         }
     }
 
+    private byte[] nopOut;
+
     /// <summary>
     /// Sends an initiator-initiated NOP-Out with ITT=0xFFFFFFFF and TTT=0xFFFFFFFF.
     /// This is a "ping" that keeps the iSCSI session alive without requiring a response.
     /// </summary>
-    private void SendNopOut()
+    private async ValueTask SendNopOutAsync()
     {
-        var nopOut = new byte[48];
-        // Byte 0: Immediate (0x40) | OpCode NopOut (0x00)
-        nopOut[0] = 0x40;
-        // Byte 1: Final bit
-        nopOut[1] = 0x80;
-        // Bytes 16-19: ITT = 0xFFFFFFFF (no response expected)
-        EndianUtilities.WriteBytesBigEndian(0xFFFFFFFF, nopOut, 16);
-        // Bytes 20-23: TTT = 0xFFFFFFFF
-        EndianUtilities.WriteBytesBigEndian(0xFFFFFFFF, nopOut, 20);
+        if (nopOut is null)
+        {
+            nopOut = new byte[48];
+
+            // Byte 0: Immediate (0x40) | OpCode NopOut (0x00)
+            nopOut[0] = 0x40;
+            // Byte 1: Final bit
+            nopOut[1] = 0x80;
+            // Bytes 16-19: ITT = 0xFFFFFFFF (no response expected)
+            EndianUtilities.WriteBytesBigEndian(0xFFFFFFFF, nopOut, 16);
+            // Bytes 20-23: TTT = 0xFFFFFFFF
+            EndianUtilities.WriteBytesBigEndian(0xFFFFFFFF, nopOut, 20);
+        }
+
         // Bytes 24-27: CmdSN (not incremented for immediate PDUs)
         EndianUtilities.WriteBytesBigEndian(Session.CommandSequenceNumber, nopOut, 24);
         // Bytes 28-31: ExpStatSN
         EndianUtilities.WriteBytesBigEndian(ExpectedStatusSequenceNumber, nopOut, 28);
 
-        _stream.Write(nopOut, 0, nopOut.Length);
-        _stream.Flush();
+        await _stream.WriteAsync(nopOut).ConfigureAwait(false);
+
+        await _stream.FlushAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -227,147 +243,148 @@ internal sealed class Connection : IDisposable
     public int Send(ScsiCommand cmd, ReadOnlySpan<byte> outBuffer, Span<byte> inBuffer)
     {
         _streamSemaphore.Wait();
+
         try
         {
-        for (var i = 0; ; i++)
-        {
-            try
+            for (var i = 0; ; i++)
             {
-                // RFC 3720 Bug #8a: Allocate new Task Tag for this command
-                // Originally added because we thought each command must have a unique ITT
-                // TESTING RESULT: NOT NECESSARY - Test passes without this call
-                // The Session already maintains ITT correctly without explicit increment here
-                // Leaving commented for reference in case unique ITT per command is needed in future
-                //Session.NextTaskTag();
-
-                // RFC 3720: DataSN starts at 0 for each new command
-                var expectedDataSN = 0u;
-
-                var req = new CommandRequest(this, cmd.TargetLun);
-
-                var outBufferCount = outBuffer.Length;
-                var inBufferMax = inBuffer.Length;
-
-                var toSend = Math.Min(outBufferCount, Session.ImmediateData ? Session.FirstBurstLength : 0);
-
-                // F bit (isFinalData) = true means "no more unsolicited Data-Out PDUs will follow".
-                // Even if we're sending < outBufferCount, we set F=1 because any remaining data
-                // will be sent via solicited Data-Out (after R2T), not more unsolicited Data-Out.
-
-                // Simpler logic: Use buffer sizes directly
-                var expectedTransferLength = outBufferCount != 0 ? (uint)outBufferCount : (uint)inBufferMax;
-
-                var packet = req.GetBytes(cmd,
-                                          immediateData: outBuffer.Slice(0, toSend),
-                                          isFinalData: true,
-                                          willRead: inBufferMax != 0,
-                                          willWrite: outBufferCount != 0,
-                                          expected: expectedTransferLength);
-
-                _stream.Write(packet, 0, packet.Length);
-                _stream.Flush();
-
-                var numSent = toSend;
-                while (numSent < outBufferCount)
+                try
                 {
-                    var pdu = ReadPdu();
+                    // RFC 3720 Bug #8a: Allocate new Task Tag for this command
+                    // Originally added because we thought each command must have a unique ITT
+                    // TESTING RESULT: NOT NECESSARY - Test passes without this call
+                    // The Session already maintains ITT correctly without explicit increment here
+                    // Leaving commented for reference in case unique ITT per command is needed in future
+                    //Session.NextTaskTag();
 
-                    var resp = ParseResponse<ReadyToTransferPacket>(pdu);
-                    var numApproved = (int)resp.DesiredTransferLength;
-                    var targetTransferTag = resp.TargetTransferTag;
+                    // RFC 3720: DataSN starts at 0 for each new command
+                    var expectedDataSN = 0u;
 
-                    // DataSN resets to 0 for each R2T (not continuous across multiple R2Ts)
-                    var pktsSent = 0;
-                    while (numApproved > 0)
+                    var req = new CommandRequest(this, cmd.TargetLun);
+
+                    var outBufferCount = outBuffer.Length;
+                    var inBufferMax = inBuffer.Length;
+
+                    var toSend = Math.Min(outBufferCount, Session.ImmediateData ? Session.FirstBurstLength : 0);
+
+                    // F bit (isFinalData) = true means "no more unsolicited Data-Out PDUs will follow".
+                    // Even if we're sending < outBufferCount, we set F=1 because any remaining data
+                    // will be sent via solicited Data-Out (after R2T), not more unsolicited Data-Out.
+
+                    // Simpler logic: Use buffer sizes directly
+                    var expectedTransferLength = outBufferCount != 0 ? (uint)outBufferCount : (uint)inBufferMax;
+
+                    var packet = req.GetBytes(cmd,
+                                              immediateData: outBuffer.Slice(0, toSend),
+                                              isFinalData: true,
+                                              willRead: inBufferMax != 0,
+                                              willWrite: outBufferCount != 0,
+                                              expected: expectedTransferLength);
+
+                    _stream.Write(packet, 0, packet.Length);
+                    _stream.Flush();
+
+                    var numSent = toSend;
+                    while (numSent < outBufferCount)
                     {
-                        toSend = Math.Min(Math.Min(outBufferCount - numSent, numApproved), MaxTargetReceiveDataSegmentLength ?? MaxInitiatorTransmitDataSegmentLength);
+                        var pdu = ReadPdu();
 
-                        var pkt = new DataOutPacket(this, cmd.TargetLun);
-                        var currentDataSN = pktsSent++;
-                        
-                        packet = pkt.GetBytes(data: outBuffer.Slice(numSent, toSend),
-                                              isFinalData: toSend == numApproved,
-                                              dataSeqNumber: currentDataSN,
-                                              bufferOffset: (uint)numSent,
-                                              targetTransferTag: targetTransferTag);
+                        var resp = ParseResponse<ReadyToTransferPacket>(pdu);
+                        var numApproved = (int)resp.DesiredTransferLength;
+                        var targetTransferTag = resp.TargetTransferTag;
 
-                        _stream.Write(packet, 0, packet.Length);
-                        _stream.Flush();
-
-                        numApproved -= toSend;
-                        numSent += toSend;
-                    }
-                }
-
-                var isFinal = false;
-                var numRead = 0;
-                while (!isFinal)
-                {
-                    var pdu = ReadPdu();
-
-                    if (pdu.OpCode == OpCode.ScsiResponse)
-                    {
-                        var resp = ParseResponse<Response>(pdu);
-
-                        if (resp.StatusPresent && resp.Status == ScsiStatus.CheckCondition)
+                        // DataSN resets to 0 for each R2T (not continuous across multiple R2Ts)
+                        var pktsSent = 0;
+                        while (numApproved > 0)
                         {
-                            var senseLength = EndianUtilities.ToUInt16BigEndian(pdu.ContentData, 0);
-                            var senseData = pdu.ContentData.AsSpan(2, senseLength).ToArray();
+                            toSend = Math.Min(Math.Min(outBufferCount - numSent, numApproved), MaxTargetReceiveDataSegmentLength ?? MaxInitiatorTransmitDataSegmentLength);
 
-                            if (i == 0 && ScsiSenseParser.TryParse(senseData, out var sense) && sense.IndicatesRetryRequired)
+                            var pkt = new DataOutPacket(this, cmd.TargetLun);
+                            var currentDataSN = pktsSent++;
+
+                            packet = pkt.GetBytes(data: outBuffer.Slice(numSent, toSend),
+                                                  isFinalData: toSend == numApproved,
+                                                  dataSeqNumber: currentDataSN,
+                                                  bufferOffset: (uint)numSent,
+                                                  targetTransferTag: targetTransferTag);
+
+                            _stream.Write(packet, 0, packet.Length);
+                            _stream.Flush();
+
+                            numApproved -= toSend;
+                            numSent += toSend;
+                        }
+                    }
+
+                    var isFinal = false;
+                    var numRead = 0;
+                    while (!isFinal)
+                    {
+                        var pdu = ReadPdu();
+
+                        if (pdu.OpCode == OpCode.ScsiResponse)
+                        {
+                            var resp = ParseResponse<Response>(pdu);
+
+                            if (resp.StatusPresent && resp.Status == ScsiStatus.CheckCondition)
                             {
-                                goto retry;
+                                var senseLength = EndianUtilities.ToUInt16BigEndian(pdu.ContentData, 0);
+                                var senseData = pdu.ContentData.AsSpan(2, senseLength).ToArray();
+
+                                if (i == 0 && ScsiSenseParser.TryParse(senseData, out var sense) && sense.IndicatesRetryRequired)
+                                {
+                                    goto retry;
+                                }
+
+                                throw new ScsiCommandException(resp.Status, senseData);
                             }
 
-                            throw new ScsiCommandException(resp.Status, senseData);
-                        }
+                            if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
+                            {
+                                throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
+                            }
 
-                        if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
+                            isFinal = resp.Header.FinalPdu;
+                        }
+                        else if (pdu.OpCode == OpCode.ScsiDataIn)
                         {
-                            throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
-                        }
+                            var resp = ParseResponse<DataInPacket>(pdu);
 
-                        isFinal = resp.Header.FinalPdu;
+                            // RFC 3720 Section 10.7.4: Validate DataSN sequence
+                            if (resp.DataSequenceNumber != expectedDataSN)
+                            {
+                                throw new InvalidProtocolException($"DataSN mismatch: received {resp.DataSequenceNumber}, expected {expectedDataSN}");
+                            }
+
+                            if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
+                            {
+                                throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
+                            }
+
+                            if (resp.ReadData != null)
+                            {
+                                resp.ReadData.AsSpan().CopyTo(inBuffer.Slice((int)resp.BufferOffset));
+                                numRead += resp.ReadData.Length;
+                            }
+
+                            isFinal = resp.Header.FinalPdu;
+
+                            expectedDataSN++;
+                        }
                     }
-                    else if (pdu.OpCode == OpCode.ScsiDataIn)
-                    {
-                        var resp = ParseResponse<DataInPacket>(pdu);
 
-                        // RFC 3720 Section 10.7.4: Validate DataSN sequence
-                        if (resp.DataSequenceNumber != expectedDataSN)
-                        {
-                            throw new InvalidProtocolException($"DataSN mismatch: received {resp.DataSequenceNumber}, expected {expectedDataSN}");
-                        }
-
-                        if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
-                        {
-                            throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
-                        }
-
-                        if (resp.ReadData != null)
-                        {
-                            resp.ReadData.AsSpan().CopyTo(inBuffer.Slice((int)resp.BufferOffset));
-                            numRead += resp.ReadData.Length;
-                        }
-
-                        isFinal = resp.Header.FinalPdu;
-
-                        expectedDataSN++;
-                    }
+                    return Math.Max(numRead, numSent);
+                }
+                finally
+                {
+                    Session.NextTaskTag();
+                    Session.NextCommandSequenceNumber();
                 }
 
-                return Math.Max(numRead, numSent);
+                retry:
+                {
+                }
             }
-            finally
-            {
-                Session.NextTaskTag();
-                Session.NextCommandSequenceNumber();
-            }
-
-            retry:
-            {
-            }
-        }
         }
         finally
         {
@@ -386,125 +403,126 @@ internal sealed class Connection : IDisposable
     public async ValueTask<int> SendAsync(ScsiCommand cmd, ReadOnlyMemory<byte> outBuffer, Memory<byte> inBuffer, CancellationToken cancellationToken)
     {
         await _streamSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
         try
         {
-        for (var i = 0; ; i++)
-        {
-            try
+            for (var i = 0; ; i++)
             {
-                // RFC 3720: DataSN starts at 0 for each new command
-                var expectedDataSN = 0u;
-
-                var req = new CommandRequest(this, cmd.TargetLun);
-
-                var outBufferCount = outBuffer.Length;
-                var inBufferMax = inBuffer.Length;
-
-                var toSend = Math.Min(outBufferCount, Session.ImmediateData ? Session.FirstBurstLength : 0);
-
-                // F bit (isFinalData) = true means "no more unsolicited Data-Out PDUs will follow".
-                // Even if we're sending < outBufferCount, we set F=1 because any remaining data
-                // will be sent via solicited Data-Out (after R2T), not more unsolicited Data-Out.
-
-                // Simpler logic: Use buffer sizes directly
-                var expectedTransferLength = outBufferCount != 0 ? (uint)outBufferCount : (uint)inBufferMax;
-
-                var packet = req.GetBytes(cmd, outBuffer.Span.Slice(0, toSend), true, inBufferMax != 0, outBufferCount != 0, expectedTransferLength);
-                await _stream.WriteAsync(packet, cancellationToken).ConfigureAwait(false);
-                await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
-                var numSent = toSend;
-                var pktsSent = 0;
-                while (numSent < outBufferCount)
+                try
                 {
-                    var pdu = await ReadPduAsync(cancellationToken).ConfigureAwait(false);
+                    // RFC 3720: DataSN starts at 0 for each new command
+                    var expectedDataSN = 0u;
 
-                    var resp = ParseResponse<ReadyToTransferPacket>(pdu);
-                    var numApproved = (int)resp.DesiredTransferLength;
-                    var targetTransferTag = resp.TargetTransferTag;
+                    var req = new CommandRequest(this, cmd.TargetLun);
 
-                    while (numApproved > 0)
+                    var outBufferCount = outBuffer.Length;
+                    var inBufferMax = inBuffer.Length;
+
+                    var toSend = Math.Min(outBufferCount, Session.ImmediateData ? Session.FirstBurstLength : 0);
+
+                    // F bit (isFinalData) = true means "no more unsolicited Data-Out PDUs will follow".
+                    // Even if we're sending < outBufferCount, we set F=1 because any remaining data
+                    // will be sent via solicited Data-Out (after R2T), not more unsolicited Data-Out.
+
+                    // Simpler logic: Use buffer sizes directly
+                    var expectedTransferLength = outBufferCount != 0 ? (uint)outBufferCount : (uint)inBufferMax;
+
+                    var packet = req.GetBytes(cmd, outBuffer.Span.Slice(0, toSend), true, inBufferMax != 0, outBufferCount != 0, expectedTransferLength);
+                    await _stream.WriteAsync(packet, cancellationToken).ConfigureAwait(false);
+                    await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                    var numSent = toSend;
+                    var pktsSent = 0;
+                    while (numSent < outBufferCount)
                     {
-                        toSend = Math.Min(Math.Min(outBufferCount - numSent, numApproved), MaxTargetReceiveDataSegmentLength ?? MaxInitiatorTransmitDataSegmentLength);
+                        var pdu = await ReadPduAsync(cancellationToken).ConfigureAwait(false);
 
-                        var pkt = new DataOutPacket(this, cmd.TargetLun);
-                        var currentDataSN = pktsSent++;
-                        packet = pkt.GetBytes(outBuffer.Span.Slice(numSent, toSend), toSend == numApproved, currentDataSN, (uint)numSent, targetTransferTag);
-                        await _stream.WriteAsync(packet, cancellationToken).ConfigureAwait(false);
-                        await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                        var resp = ParseResponse<ReadyToTransferPacket>(pdu);
+                        var numApproved = (int)resp.DesiredTransferLength;
+                        var targetTransferTag = resp.TargetTransferTag;
 
-                        numApproved -= toSend;
-                        numSent += toSend;
-                    }
-                }
-
-                var isFinal = false;
-                var numRead = 0;
-                while (!isFinal)
-                {
-                    var pdu = await ReadPduAsync(cancellationToken).ConfigureAwait(false);
-
-                    if (pdu.OpCode == OpCode.ScsiResponse)
-                    {
-                        var resp = ParseResponse<Response>(pdu);
-
-                        if (resp.StatusPresent && resp.Status == ScsiStatus.CheckCondition)
+                        while (numApproved > 0)
                         {
-                            var senseLength = EndianUtilities.ToUInt16BigEndian(pdu.ContentData, 0);
-                            var senseData = pdu.ContentData.AsSpan(2, senseLength).ToArray();
+                            toSend = Math.Min(Math.Min(outBufferCount - numSent, numApproved), MaxTargetReceiveDataSegmentLength ?? MaxInitiatorTransmitDataSegmentLength);
 
-                            if (i == 0 && ScsiSenseParser.TryParse(senseData, out var sense) && sense.IndicatesRetryRequired)
+                            var pkt = new DataOutPacket(this, cmd.TargetLun);
+                            var currentDataSN = pktsSent++;
+                            packet = pkt.GetBytes(outBuffer.Span.Slice(numSent, toSend), toSend == numApproved, currentDataSN, (uint)numSent, targetTransferTag);
+                            await _stream.WriteAsync(packet, cancellationToken).ConfigureAwait(false);
+                            await _stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+                            numApproved -= toSend;
+                            numSent += toSend;
+                        }
+                    }
+
+                    var isFinal = false;
+                    var numRead = 0;
+                    while (!isFinal)
+                    {
+                        var pdu = await ReadPduAsync(cancellationToken).ConfigureAwait(false);
+
+                        if (pdu.OpCode == OpCode.ScsiResponse)
+                        {
+                            var resp = ParseResponse<Response>(pdu);
+
+                            if (resp.StatusPresent && resp.Status == ScsiStatus.CheckCondition)
                             {
-                                goto retry;
+                                var senseLength = EndianUtilities.ToUInt16BigEndian(pdu.ContentData, 0);
+                                var senseData = pdu.ContentData.AsSpan(2, senseLength).ToArray();
+
+                                if (i == 0 && ScsiSenseParser.TryParse(senseData, out var sense) && sense.IndicatesRetryRequired)
+                                {
+                                    goto retry;
+                                }
+
+                                throw new ScsiCommandException(resp.Status, senseData);
                             }
 
-                            throw new ScsiCommandException(resp.Status, senseData);
-                        }
+                            if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
+                            {
+                                throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
+                            }
 
-                        if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
+                            isFinal = resp.Header.FinalPdu;
+                        }
+                        else if (pdu.OpCode == OpCode.ScsiDataIn)
                         {
-                            throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
-                        }
+                            var resp = ParseResponse<DataInPacket>(pdu);
 
-                        isFinal = resp.Header.FinalPdu;
+                            // RFC 3720 Section 10.7.4: Validate DataSN sequence
+                            if (resp.DataSequenceNumber != expectedDataSN)
+                            {
+                                throw new InvalidProtocolException($"DataSN mismatch: received {resp.DataSequenceNumber}, expected {expectedDataSN}");
+                            }
+                            expectedDataSN++;
+
+                            if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
+                            {
+                                throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
+                            }
+
+                            if (resp.ReadData != null)
+                            {
+                                resp.ReadData.CopyTo(inBuffer.Slice((int)resp.BufferOffset));
+                                numRead += resp.ReadData.Length;
+                            }
+
+                            isFinal = resp.Header.FinalPdu;
+                        }
                     }
-                    else if (pdu.OpCode == OpCode.ScsiDataIn)
-                    {
-                        var resp = ParseResponse<DataInPacket>(pdu);
 
-                        // RFC 3720 Section 10.7.4: Validate DataSN sequence
-                        if (resp.DataSequenceNumber != expectedDataSN)
-                        {
-                            throw new InvalidProtocolException($"DataSN mismatch: received {resp.DataSequenceNumber}, expected {expectedDataSN}");
-                        }
-                        expectedDataSN++;
-
-                        if (resp.StatusPresent && resp.Status != ScsiStatus.Good)
-                        {
-                            throw new ScsiCommandException(resp.Status, "Target indicated SCSI failure");
-                        }
-
-                        if (resp.ReadData != null)
-                        {
-                            resp.ReadData.CopyTo(inBuffer.Slice((int)resp.BufferOffset));
-                            numRead += resp.ReadData.Length;
-                        }
-
-                        isFinal = resp.Header.FinalPdu;
-                    }
+                    return Math.Max(numRead, numSent);
+                }
+                finally
+                {
+                    Session.NextTaskTag();
+                    Session.NextCommandSequenceNumber();
                 }
 
-                return Math.Max(numRead, numSent);
+                retry:
+                {
+                }
             }
-            finally
-            {
-                Session.NextTaskTag();
-                Session.NextCommandSequenceNumber();
-            }
-
-            retry:
-            {
-            }
-        }
         }
         finally
         {


### PR DESCRIPTION
## Problem

During idle periods (no active I/O on the iSCSI session) the target enforces its DefaultTime2Retain/DefaultTime2Wait timeout and will silently drop the session. The next SCSI command then fails with a broken-pipe / EOF error instead of a clean retry, causing the caller to see an unexpected I/O error.

A second, related issue is that DiscUtils had no handler for **target-initiated NOP-In** PDUs at all. A target can send a NOP-In at any time to probe the initiator, and the RFC requires the initiator to echo it back with a NOP-Out. Without this handler the PDU was returned to the caller as an unrecognised opcode, corrupting the command/response stream.

## Fix – changes in Connection.cs

### 1 – SemaphoreSlim _streamSemaphore
All traffic that touches the underlying NetworkStream (writes in Send, SendAsync, Logout, and the new keepalive callback; reads in ReadPdu / ReadPduAsync) is now serialised by a SemaphoreSlim(1,1). This prevents the timer callback from interleaving with an in-flight command.

### 2 – Timer _keepAliveTimer + KeepAliveCallback
Started immediately after the login negotiation completes. It fires every **10 seconds** and sends a NOP-Out ping. If the semaphore is already held (a real command is in progress) the tick is silently skipped — it simply waits for the next interval. Any IOException or ObjectDisposedException during the ping is swallowed; the broken connection will be surfaced naturally on the next real command.

### 3 – SendNopOut
Builds and sends an initiator-initiated NOP-Out with **ITT = 0xFFFFFFFF** and **TTT = 0xFFFFFFFF** (RFC 3720 §10.18). With these reserved values the target **must not** send a NOP-In response, so there is no extra PDU to read — the keepalive is purely write-side.

### 4 – HandleNopIn
Responds to a **target-initiated** NOP-In (TTT ≠ 0xFFFFFFFF) by sending a NOP-Out that echoes the TTT (RFC 3720 §10.19). Critically, SeenStatusSequenceNumber() is **not** called here: the RFC states that the StatSN carried in a target-initiated NOP-In is informational and does not consume a sequence number — calling it would cause the next real response to fail with a StatSN mismatch.

### 5 – ReadPdu / ReadPduAsync – NOP-In loop
Both sync and async read paths now loop over consecutive NOP-In PDUs (max 16) before returning the next real response PDU, ensuring neither path is disrupted by a target ping arriving between command and response.

## RFC references
- RFC 3720 §10.18 – NOP-Out (initiator-initiated ping)
- RFC 3720 §10.19 – NOP-In (target-initiated ping and response)