### PR TITLE
Fix exFAT boot signature offset

### DIFF
--- a/Library/DiscUtils.ExFat/Internal/Partition/ExFatBootSector.cs
+++ b/Library/DiscUtils.ExFat/Internal/Partition/ExFatBootSector.cs
@@ -177,7 +177,7 @@ public class ExFatBootSector
     /// <value>
     ///   <c>true</c> if this instance is valid; otherwise, <c>false</c>.
     /// </value>
-    public bool IsValid => IsExFat && _bytes[BytesPerSector.Value - 2] == 0x55 && _bytes[BytesPerSector.Value - 1] == 0xAA && IsChecksumValid();
+    public bool IsValid => IsExFat && _bytes[510] == 0x55 && _bytes[511] == 0xAA && IsChecksumValid();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ExFatBootSector"/> class.


### PR DESCRIPTION
While trying to work with some raw filesystem dumps, I came across one exFAT dump which had a sector size of 4096 instead of the usual 512 and wouldn't pass validation.

Upon closer inspection it looks like that DiscUtils derives the position of the boot signature in the VBR from the sector size, which doesn't seem correct according to docs; it's always supposed to be located at offset 510.
https://learn.microsoft.com/en-us/windows/win32/fileio/exfat-specification#31-main-and-backup-boot-sector-sub-regions

After correcting this, my dump read just fine.