### PR TITLE
Fix five regressions on LTRData.DiscUtils-initial (registry, NTFS, dynamic-disk hang, sparse-stream)

### DIFF
--- a/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
+++ b/Library/DiscUtils.Ntfs/NtfsFileSystem.cs
@@ -930,6 +930,13 @@ public class NtfsFileSystem : DiscFileSystem, IClusterBasedFileSystem,
             var dirEntry = GetDirectoryEntry(dirEntryPath)
                 ?? throw new FileNotFoundException("File not found", path);
 
+            // Ordinary file length request, use info from the directory entry for efficiency - if allowed.
+            if (NtfsOptions.FileLengthFromDirectoryEntries && attributeName == null &&
+                attributeType == AttributeType.Data)
+            {
+                return (long)dirEntry.Details.RealSize;
+            }
+
             var file = GetFile(dirEntry.Reference);
             var attr = file.GetAttribute(attributeType, attributeName)
                 ?? throw new FileNotFoundException($"No such attribute '{attributeName}({attributeType})'");

--- a/Library/DiscUtils.Registry/Bin.cs
+++ b/Library/DiscUtils.Registry/Bin.cs
@@ -187,7 +187,7 @@ internal sealed class Bin
 
     internal int AllocateCell(int size)
     {
-        if (size < 8 || (size % 0x7) != 0)
+        if (size < 8 || (size & 0x7) != 0)
         {
             throw new ArgumentException("Invalid cell size");
         }

--- a/Library/DiscUtils.Registry/SubKeyIndirectListCell.cs
+++ b/Library/DiscUtils.Registry/SubKeyIndirectListCell.cs
@@ -160,33 +160,22 @@ internal sealed class SubKeyIndirectListCell : ListCell
 
     internal override int LinkSubKey(string name, int cellIndex)
     {
-        // Look for the first sublist that has a subkey name greater than name
-        if (ListType == "ri")
+        // As in UnlinkSubKey, a list's entries can be a mix of sublists ("ri") and key nodes ("li"), so dispatch
+        // on the actual cell type rather than on ListType (avoids a KeyNodeCell -> ListCell InvalidCastException).
+        // Look for the first sublist/key node whose name is greater than the new name.
+        for (var i = 0; i < CellIndexes.Count; ++i)
         {
-            if (CellIndexes.Count == 0)
+            var cell = _hive.GetCell<Cell>(CellIndexes[i]);
+            if (cell is ListCell listCell)
             {
-                throw new NotImplementedException("Empty indirect list");
-            }
-
-            for (var i = 0; i < CellIndexes.Count - 1; ++i)
-            {
-                var cell = _hive.GetCell<ListCell>(CellIndexes[i]);
-                if (cell.FindKey(name, out var tempIndex) <= 0)
+                // Descend into the last sublist, or the first whose range can already hold the new name.
+                if (i == CellIndexes.Count - 1 || listCell.FindKey(name, out _) <= 0)
                 {
-                    CellIndexes[i] = cell.LinkSubKey(name, cellIndex);
+                    CellIndexes[i] = listCell.LinkSubKey(name, cellIndex);
                     return _hive.UpdateCell(this, false);
                 }
             }
-
-            var lastCell = _hive.GetCell<ListCell>(CellIndexes[CellIndexes.Count - 1]);
-            CellIndexes[CellIndexes.Count - 1] = lastCell.LinkSubKey(name, cellIndex);
-            return _hive.UpdateCell(this, false);
-        }
-
-        for (var i = 0; i < CellIndexes.Count; ++i)
-        {
-            var cell = _hive.GetCell<KeyNodeCell>(CellIndexes[i]);
-            if (string.Compare(name, cell.Name, StringComparison.OrdinalIgnoreCase) < 0)
+            else if (string.Compare(name, ((KeyNodeCell)cell).Name, StringComparison.OrdinalIgnoreCase) < 0)
             {
                 CellIndexes.Insert(i, cellIndex);
                 return _hive.UpdateCell(this, true);
@@ -199,20 +188,19 @@ internal sealed class SubKeyIndirectListCell : ListCell
 
     internal override int UnlinkSubKey(string name)
     {
-        if (ListType == "ri")
+        // A "ri" list references sublists and a "li" list references key nodes, but in practice the entries of a
+        // single list can be a mix of both (the read paths - Count/EnumerateKeyNames/EnumerateKeys/DoFindKey -
+        // already tolerate this). Dispatch on the actual cell type instead of on ListType, otherwise deleting a
+        // key whose containing list has a mismatched entry throws InvalidCastException (KeyNodeCell -> ListCell).
+        for (var i = 0; i < CellIndexes.Count; ++i)
         {
-            if (CellIndexes.Count == 0)
+            var cell = _hive.GetCell<Cell>(CellIndexes[i]);
+            if (cell is ListCell listCell)
             {
-                throw new NotImplementedException("Empty indirect list");
-            }
-
-            for (var i = 0; i < CellIndexes.Count; ++i)
-            {
-                var cell = _hive.GetCell<ListCell>(CellIndexes[i]);
-                if (cell.FindKey(name, out var tempIndex) <= 0)
+                if (listCell.FindKey(name, out _) <= 0)
                 {
-                    CellIndexes[i] = cell.UnlinkSubKey(name);
-                    if (cell.Count == 0)
+                    CellIndexes[i] = listCell.UnlinkSubKey(name);
+                    if (listCell.Count == 0)
                     {
                         _hive.FreeCell(CellIndexes[i]);
                         CellIndexes.RemoveAt(i);
@@ -221,17 +209,10 @@ internal sealed class SubKeyIndirectListCell : ListCell
                     return _hive.UpdateCell(this, false);
                 }
             }
-        }
-        else
-        {
-            for (var i = 0; i < CellIndexes.Count; ++i)
+            else if (string.Equals(name, ((KeyNodeCell)cell).Name, StringComparison.OrdinalIgnoreCase))
             {
-                var cell = _hive.GetCell<KeyNodeCell>(CellIndexes[i]);
-                if (string.Equals(name, cell.Name, StringComparison.OrdinalIgnoreCase))
-                {
-                    CellIndexes.RemoveAt(i);
-                    return _hive.UpdateCell(this, true);
-                }
+                CellIndexes.RemoveAt(i);
+                return _hive.UpdateCell(this, true);
             }
         }
 

--- a/Library/DiscUtils.Streams/SparseStream.cs
+++ b/Library/DiscUtils.Streams/SparseStream.cs
@@ -656,7 +656,11 @@ public abstract class SparseStream : CompatibilityStream
 
         public override long Length => content.Length;
 
-        public override long Position { get; set; }
+        public override long Position
+        {
+            get { lock (sync) { return content.Position; } }
+            set { lock (sync) { content.Position = value; } }
+        }
 
         public override void Flush()
         {

--- a/Library/DiscUtils.Vhd/DynamicStream.cs
+++ b/Library/DiscUtils.Vhd/DynamicStream.cs
@@ -174,7 +174,7 @@ public class DynamicStream : MappedStream
 
                 if (offsetInSector != 0 || toRead < Sizes.Sector)
                 {
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((blockBitmap[sectorInBlock / 8] & mask) != 0)
                     {
                         var extentStart = (_blockAllocationTable[block] + sectorInBlock) *
@@ -190,7 +190,7 @@ public class DynamicStream : MappedStream
                     // Processing at least one whole sector, read as many as possible
                     var toReadSectors = toRead / Sizes.Sector;
 
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     var readFromParent = (blockBitmap[sectorInBlock / 8] & mask) == 0;
 
                     var numSectors = 1;
@@ -274,7 +274,7 @@ public class DynamicStream : MappedStream
 
                 if (offsetInSector != 0 || toRead < Sizes.Sector)
                 {
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
 
                     if ((blockBitmap[sectorInBlock / 8] & mask) != 0)
                     {
@@ -296,7 +296,7 @@ public class DynamicStream : MappedStream
                     // Processing at least one whole sector, read as many as possible
                     var toReadSectors = toRead / Sizes.Sector;
 
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     var readFromParent = (blockBitmap[sectorInBlock / 8] & mask) == 0;
 
                     var numSectors = 1;
@@ -377,7 +377,7 @@ public class DynamicStream : MappedStream
 
                 if (offsetInSector != 0 || toRead < Sizes.Sector)
                 {
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((blockBitmap[sectorInBlock / 8] & mask) != 0)
                     {
                         _fileStream.Position = (_blockAllocationTable[block] + sectorInBlock) *
@@ -398,7 +398,7 @@ public class DynamicStream : MappedStream
                     // Processing at least one whole sector, read as many as possible
                     var toReadSectors = toRead / Sizes.Sector;
 
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     var readFromParent = (blockBitmap[sectorInBlock / 8] & mask) == 0;
 
                     var numSectors = 1;
@@ -479,7 +479,7 @@ public class DynamicStream : MappedStream
 
                 if (offsetInSector != 0 || toRead < Sizes.Sector)
                 {
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((blockBitmap[sectorInBlock / 8] & mask) != 0)
                     {
                         _fileStream.Position = (_blockAllocationTable[block] + sectorInBlock) *
@@ -500,7 +500,7 @@ public class DynamicStream : MappedStream
                     // Processing at least one whole sector, read as many as possible
                     var toReadSectors = toRead / Sizes.Sector;
 
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     var readFromParent = (blockBitmap[sectorInBlock / 8] & mask) == 0;
 
                     var numSectors = 1;
@@ -621,7 +621,7 @@ public class DynamicStream : MappedStream
                 // Reduce the write to just the end of the current sector
                 toWrite = Math.Min(count - numWritten, Sizes.Sector - offsetInSector);
 
-                var sectorMask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                var sectorMask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
 
                 var sectorStart = (_blockAllocationTable[block] + sectorInBlock) * Sizes.Sector +
                                    _blockBitmapSize;
@@ -665,7 +665,7 @@ public class DynamicStream : MappedStream
                 // Update all of the bits in the block bitmap
                 for (var i = offset; i < offset + toWrite; i += Sizes.Sector)
                 {
-                    var sectorMask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var sectorMask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((_blockBitmaps[block][sectorInBlock / 8] & sectorMask) == 0)
                     {
                         _blockBitmaps[block][sectorInBlock / 8] |= sectorMask;
@@ -726,7 +726,7 @@ public class DynamicStream : MappedStream
                 // Reduce the write to just the end of the current sector
                 toWrite = Math.Min(buffer.Length - numWritten, Sizes.Sector - offsetInSector);
 
-                var sectorMask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                var sectorMask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
 
                 var sectorStart = (_blockAllocationTable[block] + sectorInBlock) * Sizes.Sector +
                                    _blockBitmapSize;
@@ -778,7 +778,7 @@ public class DynamicStream : MappedStream
                 // Update all of the bits in the block bitmap
                 for (var i = 0; i < toWrite; i += Sizes.Sector)
                 {
-                    var sectorMask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var sectorMask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((_blockBitmaps[block][sectorInBlock / 8] & sectorMask) == 0)
                     {
                         _blockBitmaps[block][sectorInBlock / 8] |= sectorMask;
@@ -841,7 +841,7 @@ public class DynamicStream : MappedStream
                 // Reduce the write to just the end of the current sector
                 toWrite = Math.Min(buffer.Length - numWritten, Sizes.Sector - offsetInSector);
 
-                var sectorMask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                var sectorMask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
 
                 var sectorStart = (_blockAllocationTable[block] + sectorInBlock) * Sizes.Sector +
                                    _blockBitmapSize;
@@ -885,7 +885,7 @@ public class DynamicStream : MappedStream
                 // Update all of the bits in the block bitmap
                 for (var i = 0; i < toWrite; i += Sizes.Sector)
                 {
-                    var sectorMask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var sectorMask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((_blockBitmaps[block][sectorInBlock / 8] & sectorMask) == 0)
                     {
                         _blockBitmaps[block][sectorInBlock / 8] |= sectorMask;
@@ -977,11 +977,11 @@ public class DynamicStream : MappedStream
 
                 if (_blockBitmaps[block][sectorInBlock / 8] == 0)
                 {
-                    pos += (8 - sectorInBlock & 0x7) * Sizes.Sector;
+                    pos += (8 - (sectorInBlock & 0x7)) * Sizes.Sector;
                 }
                 else
                 {
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((_blockBitmaps[block][sectorInBlock / 8] & mask) != 0)
                     {
                         foundStart = true;
@@ -1015,11 +1015,11 @@ public class DynamicStream : MappedStream
 
                 if (_blockBitmaps[block][sectorInBlock / 8] == 0xFF)
                 {
-                    pos += (8 - sectorInBlock & 0x7) * Sizes.Sector;
+                    pos += (8 - (sectorInBlock & 0x7)) * Sizes.Sector;
                 }
                 else
                 {
-                    var mask = (byte)(1 << (7 - sectorInBlock & 0x7));
+                    var mask = (byte)(1 << (7 - (sectorInBlock & 0x7)));
                     if ((_blockBitmaps[block][sectorInBlock / 8] & mask) == 0)
                     {
                         foundEnd = true;


### PR DESCRIPTION
Fixes five regressions currently on `LTRData.DiscUtils-initial`. With all five, the full `LibraryTests` suite passes (581 passed, 1 skipped, 0 failed, no hangs). Without them the suite cannot build/create a hive (#2), fails NTFS/ExFat reads (#3, #5), and hangs indefinitely (#4).

## 1. `SubKeyIndirectListCell` — `InvalidCastException` on mixed `ri`/`li` lists
`LinkSubKey`/`UnlinkSubKey` branched on `ListType` and hard-cast every entry, but a list can contain a mix of sublists and key nodes (the read paths already tolerate this). Deleting/adding a subkey under such a list threw `InvalidCastException: KeyNodeCell -> ListCell`. Fixed by dispatching per entry on the actual cell type, mirroring the read paths.

## 2. `Bin.AllocateCell` — 8-byte alignment check regressed to mod 7
Cells are 8-byte aligned, so the check must be `(size & 0x7) != 0`. It had been changed to `(size % 0x7) != 0` (mod 7), rejecting ~6 of every 7 valid sizes including the ~80-byte root cell, so `RegistryHive.Create()` itself throws `Invalid cell size`. Restored to `& 0x7`. (Introducing commit in a comment below.)

## 3. `NtfsFileSystem.GetFileLength` — `FileLengthFromDirectoryEntries` option ignored
The default-data-stream shortcut returning the directory entry's `RealSize` was removed, making the option a no-op and breaking `NtfsFileSystemTest.GetFileLength`. Restored the shortcut. (Introducing commit in a comment below.)

## 4. `DynamicStream` — infinite loop in sector scan (the hang)
`FindNextPresentSector`/`FindNextAbsentSector` advance with `pos += (8 - sectorInBlock & 0x7) * Sizes.Sector`. By C# precedence that is `(8 - sectorInBlock) & 0x7`, not `8 - (sectorInBlock & 0x7)`: at a byte-aligned, empty bitmap byte the original `8 - sectorInBlock % 8` advanced by 8 sectors, but the rewrite yields `8 & 7 = 0`, so `pos` never advances and extent enumeration / the dynamic VHD+VMDK builders loop forever. Parenthesized to restore the semantics. (Introducing commit in a comment below.)

## 5. `SynchronizedSparseStream` — `Position` never advances
The synchronized wrapper set `content.Position = Position` before each op but never wrote the advanced position back, so `Position` stayed frozen and reads/writes through the wrapper re-processed the same offset (e.g. `ExFat...ReadLongSparseLimited`). `Position` now delegates to `content.Position` under the lock, fixing every read/write path at once. (Introducing commit in a comment below.)
