### PR TITLE
Fix GPT protective MBR to start at LBA 1 per UEFI spec

### DIFF
--- a/Library/DiscUtils.Core/Partitions/GuidPartitionTable.cs
+++ b/Library/DiscUtils.Core/Partitions/GuidPartitionTable.cs
@@ -108,7 +108,17 @@ public sealed class GuidPartitionTable : PartitionTable
     {
         // Create the protective MBR partition record.
         var pt = BiosPartitionTable.Initialize(disk, diskGeometry);
-        pt.CreatePrimaryByCylinder(0, diskGeometry.Cylinders - 1, BiosPartitionTypes.GptProtective, false);
+
+        // The UEFI spec ("Protective MBR") requires the 0xEE record to have
+        // StartingLBA exactly 1 (the LBA of the GPT header) and SizeInLBA equal
+        // to the size of the disk minus one, capped at 0xFFFFFFFF. A cylinder
+        // aligned record starts at LBA 63 instead, which the Linux kernel
+        // (block/partitions/efi.c pmbr_part_valid, requires starting_lba == 1)
+        // and EDK2 firmware (MdeModulePkg PartitionDxe, UNPACK_UINT32(StartingLBA) == 1)
+        // reject, causing the whole GPT to be ignored. Use a sector-based record
+        // starting at LBA 1 covering the rest of the disk instead.
+        var sectorCount = disk.Length / diskGeometry.BytesPerSector;
+        pt.CreatePrimaryBySector(1, Math.Min(sectorCount - 1, uint.MaxValue), BiosPartitionTypes.GptProtective, false);
 
         // Create the GPT headers, and blank-out the entry areas
         const int EntryCount = 128;

--- a/Tests/LibraryTests/Partitions/GuidPartitionTableTest.cs
+++ b/Tests/LibraryTests/Partitions/GuidPartitionTableTest.cs
@@ -20,7 +20,9 @@
 // DEALINGS IN THE SOFTWARE.
 //
 
+using System;
 using System.IO;
+using DiscUtils;
 using DiscUtils.Partitions;
 using DiscUtils.Streams;
 using DiscUtils.Vdi;
@@ -179,6 +181,56 @@ public class GuidPartitionTableTest
 
         Assert.Equal(2, table.Count);
         Assert.Equal(sectorCount[2], table[1].SectorCount);
+    }
+
+    [Fact]
+    public void ProtectiveMbrIsSpecCompliant()
+    {
+        var ms = new MemoryStream();
+        ms.SetLength(3 * 1024 * 1024);
+        GuidPartitionTable.Initialize(ms, Geometry.FromCapacity(ms.Length));
+
+        ms.Position = 0;
+        var sector = new byte[512];
+        ms.ReadExactly(sector, 0, sector.Length);
+
+        // Boot signature.
+        Assert.Equal(0x55, sector[510]);
+        Assert.Equal(0xAA, sector[511]);
+
+        // Exactly one of the four partition records must be the 0xEE protective
+        // record; the other three must be empty (type 0x00).
+        var protectiveIndex = -1;
+        var protectiveCount = 0;
+        var emptyCount = 0;
+        for (var i = 0; i < 4; ++i)
+        {
+            var type = sector[0x1BE + 16 * i + 4];
+            if (type == 0xEE)
+            {
+                protectiveIndex = i;
+                ++protectiveCount;
+            }
+            else if (type == 0x00)
+            {
+                ++emptyCount;
+            }
+        }
+
+        Assert.Equal(1, protectiveCount);
+        Assert.Equal(3, emptyCount);
+
+        var record = sector.AsSpan(0x1BE + 16 * protectiveIndex, 16);
+
+        // Status byte must be non-bootable.
+        Assert.Equal(0, record[0]);
+
+        // UEFI spec: StartingLBA == 1 and SizeInLBA == disk size in sectors - 1.
+        var startingLba = EndianUtilities.ToUInt32LittleEndian(record.Slice(8));
+        var sizeInLba = EndianUtilities.ToUInt32LittleEndian(record.Slice(12));
+
+        Assert.Equal(1U, startingLba);
+        Assert.Equal((uint)(ms.Length / 512 - 1), sizeInLba);
     }
 
 }


### PR DESCRIPTION
## Problem

`GuidPartitionTable.Initialize` created the GPT protective MBR with `CreatePrimaryByCylinder`, which **cylinder-aligns** the 0xEE record. That places its `StartingLBA` at 63 (the first head boundary of the fake CHS geometry) and gives it a `SizeInLBA` that ends on a cylinder boundary short of the disk end.

The UEFI spec ("Protective MBR", table *"Protective MBR Partition Record"*) requires the single 0xEE record to have:

- `StartingLBA` **exactly 1** (the LBA of the GPT header), and
- `SizeInLBA` equal to the size of the disk minus one, capped at `0xFFFFFFFF`.

Because DiscUtils wrote `StartingLBA = 63`, the GPT was rejected outright by:

- **Linux kernel** — `block/partitions/efi.c` `pmbr_part_valid()` returns invalid unless `starting_lba == 1`, so the kernel ignores the GPT completely (`losetup -P`, `blkid`, and `mount` see zero partitions; the msdos fallback scanner also bails when it sees a 0xEE type).
- **EDK2 / UEFI firmware** — `MdeModulePkg` `PartitionDxe` has the same check (`UNPACK_UINT32(StartingLBA) == 1`), so disks initialized by DiscUtils could never be EFI-booted.
- **gdisk** warns: *"0xEE partition doesn't start on sector 1"*.

## Wrong vs. right (bytes at offset `0x1BE`, the first MBR partition record)

Wrong (before — cylinder aligned, `StartingLBA = 63`):

```
00 02 00 00 EE FE FF FF  3F 00 00 00  ...   <- StartingLBA = 0x0000003F (63)
                         └──────────┘
```

Right (after — sector based, `StartingLBA = 1`):

```
00 00 02 00 EE FE FF FF  01 00 00 00  ...   <- StartingLBA = 0x00000001 (1)
                         └──────────┘
```

`SizeInLBA` (the following 4 bytes) becomes `min(diskSectors - 1, 0xFFFFFFFF)`.

## Fix

Replace the cylinder-based call with a sector-based record starting at LBA 1 covering the rest of the disk:

```csharp
var sectorCount = disk.Length / diskGeometry.BytesPerSector;
pt.CreatePrimaryBySector(1, Math.Min(sectorCount - 1, uint.MaxValue), BiosPartitionTypes.GptProtective, false);
```

`BiosPartitionTable.CreatePrimaryBySector` already fills in the CHS fields and caps oversized CHS at the `1023/254/63` tuple.

## How to reproduce / test

Unit test added (`ProtectiveMbrIsSpecCompliant` in `Tests/LibraryTests/Partitions/GuidPartitionTableTest.cs`): initializes a GPT on a 3 MB `MemoryStream`, reads sector 0, and asserts the boot signature (`0x55 0xAA`), that exactly one record is type `0xEE` (the other three `0x00`), that its status byte is `0`, that `StartingLBA == 1`, and that `SizeInLBA == diskSectors - 1`.

Manual reproduction with `sgdisk` (Linux), before vs. after this patch:

```sh
# Create a 256 MB image and initialize a GPT with DiscUtils, then:
sgdisk -v disk.img
# Before: warns about the 0xEE partition not starting on sector 1
# After:  "No problems found. N free sectors ..."

# Inspect the protective MBR record directly:
od -A d -t x1 -j 446 -N 16 disk.img
# The StartingLBA field (bytes 8..11 of the record) must read: 01 00 00 00
```

Optionally, `losetup -P` + `blkid`/`lsblk` on the image: before the patch the kernel sees no partitions; after, the GPT partitions appear.
