### PR TITLE
Fix NTFS $MFTMirr to stay in sync with $MFT

### DIFF
--- a/Library/DiscUtils.Ntfs/MasterFileTable.cs
+++ b/Library/DiscUtils.Ntfs/MasterFileTable.cs
@@ -410,30 +410,54 @@ internal class MasterFileTable : IDiagnosticTraceable, IDisposable
             throw new IOException("Attempting to write over-sized MFT record");
         }
 
-        _recordStream.Position = record.MasterFileTableIndex * RecordSize;
-        record.ToStream(_recordStream, RecordSize);
-        _recordStream.Flush();
-
-        // We may have modified our own meta-data by extending the data stream, so
-        // make sure our records are up-to-date.
-        if (_self.MftRecordIsDirty)
+        // Serialize the record exactly once and write the identical bytes to both
+        // $MFT and $MFTMirr. FixupRecordBase.ToBytes calls ProtectBuffer, which
+        // increments the update sequence number on every serialization, so calling
+        // ToStream twice would store different USNs (and different fixup bytes) in
+        // each copy. NTFS implementations compare $MFTMirr to $MFT verbatim at mount
+        // time, so ntfs-3g would fail with "$MFTMirr does not match $MFT" and chkdsk
+        // would report corruption.
+        byte[] allocated = null;
+        var buffer = RecordSize <= 1024
+            ? stackalloc byte[RecordSize]
+            : (allocated = ArrayPool<byte>.Shared.Rent(RecordSize)).AsSpan(0, RecordSize);
+        try
         {
-            var dirEntry = _self.DirectoryEntry;
-            dirEntry?.UpdateFrom(_self);
+            buffer.Clear();
+            record.ToBytes(buffer);
 
-            _self.UpdateRecordInMft();
-        }
+            _recordStream.Position = record.MasterFileTableIndex * RecordSize;
+            _recordStream.Write(buffer);
+            _recordStream.Flush();
 
-        // Need to update Mirror.  OpenRaw is OK because this is short duration, and we don't
-        // extend or otherwise modify any meta-data, just the content of the Data stream.
-        if (record.MasterFileTableIndex < 4 && _self.Context.GetFileByIndex != null)
-        {
-            var mftMirror = _self.Context.GetFileByIndex(MftMirrorIndex);
-            if (mftMirror != null)
+            // We may have modified our own meta-data by extending the data stream, so
+            // make sure our records are up-to-date.
+            if (_self.MftRecordIsDirty)
             {
-                using var s = mftMirror.OpenStream(AttributeType.Data, null, FileAccess.ReadWrite);
-                s.Position = record.MasterFileTableIndex * RecordSize;
-                record.ToStream(s, RecordSize);
+                var dirEntry = _self.DirectoryEntry;
+                dirEntry?.UpdateFrom(_self);
+
+                _self.UpdateRecordInMft();
+            }
+
+            // Need to update Mirror.  OpenRaw is OK because this is short duration, and we don't
+            // extend or otherwise modify any meta-data, just the content of the Data stream.
+            if (record.MasterFileTableIndex < 4 && _self.Context.GetFileByIndex != null)
+            {
+                var mftMirror = _self.Context.GetFileByIndex(MftMirrorIndex);
+                if (mftMirror != null)
+                {
+                    using var s = mftMirror.OpenStream(AttributeType.Data, null, FileAccess.ReadWrite);
+                    s.Position = record.MasterFileTableIndex * RecordSize;
+                    s.Write(buffer);
+                }
+            }
+        }
+        finally
+        {
+            if (allocated != null)
+            {
+                ArrayPool<byte>.Shared.Return(allocated);
             }
         }
     }

--- a/Tests/LibraryTests/Ntfs/NtfsFileSystemTest.cs
+++ b/Tests/LibraryTests/Ntfs/NtfsFileSystemTest.cs
@@ -1100,4 +1100,53 @@ public class NtfsFileSystemTest
             Assert.Equal(dummyFileSize, fs.GetFileLength("test.bin"));
         }
     }
+
+    [Fact]
+    public void MftMirrorStaysInSyncWithMft()
+    {
+        var ms = new MemoryStream();
+        ms.SetLength(64 * 1024 * 1024);
+
+        var geometry = Geometry.FromCapacity(ms.Length);
+        using (NtfsFileSystem.Format(ms, "mirror", geometry, 0, ms.Length / geometry.BytesPerSector))
+        {
+        }
+
+        using (var fs = new NtfsFileSystem(ms))
+        {
+            fs.CreateDirectory("dir");
+            var content = new byte[4096];
+            for (var i = 0; i < 400; ++i)
+            {
+                using var file = fs.OpenFile($"dir\\file{i}.bin", FileMode.CreateNew);
+                file.Write(content, 0, content.Length);
+            }
+        }
+
+        var image = ms.ToArray();
+
+        // Parse the boot sector.
+        var bytesPerSector = EndianUtilities.ToUInt16LittleEndian(image, 0x0B);
+        var sectorsPerCluster = image[0x0D];
+        var clusterBytes = bytesPerSector * sectorsPerCluster;
+        var mftCluster = EndianUtilities.ToInt64LittleEndian(image, 0x30);
+        var mirrorCluster = EndianUtilities.ToInt64LittleEndian(image, 0x38);
+
+        var rawClustersPerRecord = (sbyte)image[0x40];
+        var recordSize = rawClustersPerRecord >= 0
+            ? rawClustersPerRecord * clusterBytes
+            : 1 << (-rawClustersPerRecord);
+
+        var mftBase = mftCluster * clusterBytes;
+        var mirrorBase = mirrorCluster * clusterBytes;
+
+        for (var record = 0; record < 4; ++record)
+        {
+            var mftSlice = image.AsSpan((int)(mftBase + record * recordSize), recordSize);
+            var mirrorSlice = image.AsSpan((int)(mirrorBase + record * recordSize), recordSize);
+
+            Assert.True(mftSlice.SequenceEqual(mirrorSlice),
+                $"$MFTMirr does not match $MFT for record {record}");
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`MasterFileTable.WriteRecord` serialized each MFT record **twice** — once into the `$MFT` stream and, for records 0-3, once again into the `$MFTMirr` copy:

```csharp
record.ToStream(_recordStream, RecordSize);   // $MFT copy
...
record.ToStream(s, RecordSize);               // $MFTMirr copy
```

`FixupRecordBase.ToBytes` calls `ProtectBuffer`, which does `UpdateSequenceNumber++` on **every** serialization. So the mirror copy was always written with a USN one higher than the `$MFT` copy. The two copies therefore differ at:

- the **USN field** (offset `0x30` in the record header), and
- the **fixup bytes** (the last two bytes of every 512-byte sector of the record).

NTFS implementations compare `$MFTMirr` to `$MFT` **verbatim** at mount time, so:

- **ntfs-3g** refuses to mount: *"$MFTMirr does not match $MFT (record 0)"*.
- **chkdsk** reports corruption.

Any operation that grows the MFT rewrites the MFT's own record 0 and triggers this.

## Wrong vs. right (record 0 header, USN field at offset `0x30`)

Wrong (before — mirror serialized separately, USN bumped again):

```
$MFT     record 0 @0x30:  05 00        (USN = 5)
$MFTMirr record 0 @0x30:  06 00        (USN = 6)   <- mismatch
```

Right (after — one serialization, identical bytes to both):

```
$MFT     record 0 @0x30:  05 00        (USN = 5)
$MFTMirr record 0 @0x30:  05 00        (USN = 5)   <- identical
```

## Fix

Serialize the record exactly once into a buffer and write those same bytes to both streams, keeping the existing method structure (main write → `MftRecordIsDirty` handling → mirror write):

```csharp
byte[] allocated = null;
var buffer = RecordSize <= 1024
    ? stackalloc byte[RecordSize]
    : (allocated = ArrayPool<byte>.Shared.Rent(RecordSize)).AsSpan(0, RecordSize);
try
{
    buffer.Clear();
    record.ToBytes(buffer);                 // serialized once -> single USN

    _recordStream.Position = record.MasterFileTableIndex * RecordSize;
    _recordStream.Write(buffer);            // $MFT
    _recordStream.Flush();
    ...
    s.Write(buffer);                        // $MFTMirr - identical bytes
}
finally { if (allocated != null) ArrayPool<byte>.Shared.Return(allocated); }
```

## How to reproduce / test

Unit test added (`MftMirrorStaysInSyncWithMft` in `Tests/LibraryTests/Ntfs/NtfsFileSystemTest.cs`): formats a 64 MB NTFS volume, reopens it, creates a directory and **400 files of 4096 bytes** (which grows the MFT and rewrites record 0), then parses the boot sector to locate `$MFT` and `$MFTMirr` and **byte-compares records 0-3** of each, asserting they are identical.

The test fails on the unpatched library with exactly:

```
$MFTMirr does not match $MFT for record 0
```

(Verified by stashing the `MasterFileTable.cs` change, running the single test, observing the record-0 failure, then unstashing.)

Manual reproduction with ntfs-3g tools (Linux):

```sh
# Produce an image with the library after the 400-file workload, then:
ntfsfix -n disk.img
# Before: reports $MFTMirr does not match $MFT
# After:  "Volume is clean" / mounts OK with nothing to correct
```
