### PR TITLE
Fix LzxDecoder's handling of odd sized uncompressed blocks if that block is the final one

### DIFF
--- a/Library/DiscUtils.Core/Compression/LzxDecoder.cs
+++ b/Library/DiscUtils.Core/Compression/LzxDecoder.cs
@@ -236,7 +236,7 @@ internal ref struct LzxDecoder
 
         if ((blockSize & 1) != 0)
         {
-            if (!reader.TryReadRawByte(out _))
+            if (remainingOutput - bytesToStore > 0 && !reader.TryReadRawByte(out _))
             {
                 return false;
             }


### PR DESCRIPTION
The current implementation of LzxDecoder correctly reads the padding byte to realign the stream to 16 bits in case the uncompressed block is of an odd size. 

https://github.com/LTRData/DiscUtils/blob/aada9257377439d6b7f4be90eadeeb8e74b1ca3f/Library/DiscUtils.Core/Compression/LzxDecoder.cs#L237

However, if that's the last block there is no next block to align it for and even Microsoft's own tool doesn't append that padding byte, causing the read attempt below it to fail for valid blocks.

https://github.com/LTRData/DiscUtils/blob/aada9257377439d6b7f4be90eadeeb8e74b1ca3f/Library/DiscUtils.Core/Compression/LzxDecoder.cs#L239-L242

I couldn't find where it's documented but looking at wimlib's [implementation](https://github.com/matchaxnb/wimlib/blob/685256db2cf8df2730823a981851b3b2b4773bca/src/lzx-decompress.c#L775), they only check for that padding byte in case the block wasn't the last one, matching that behaviour.
```c
if (istream.data_bytes_left && (block_size & 1)) {
	istream.data_bytes_left--;
	istream.data++;
}
```

This PR adds the same fix to the DiscUtils' code which makes it correctly extract the files I encountered this issue with.