### PR TITLE
Fix NTFS attribute list name offset

### DIFF
--- a/Library/DiscUtils.Ntfs/AttributeListRecord.cs
+++ b/Library/DiscUtils.Ntfs/AttributeListRecord.cs
@@ -30,6 +30,9 @@ namespace DiscUtils.Ntfs;
 
 internal class AttributeListRecord : IDiagnosticTraceable, IByteArraySerializable, IComparable<AttributeListRecord>
 {
+    // The fixed fields occupy 0x1A bytes; only the overall record is aligned to 8 bytes.
+    private const byte FixedHeaderSize = 0x1A;
+
     public ushort AttributeId;
     public FileRecordReference BaseFileReference;
     public string Name;
@@ -39,7 +42,7 @@ internal class AttributeListRecord : IDiagnosticTraceable, IByteArraySerializabl
     public ulong StartVcn;
     public AttributeType Type;
 
-    public int Size => MathUtilities.RoundUp(0x20 + (string.IsNullOrEmpty(Name) ? 0 : MemoryMarshal.AsBytes(Name.AsSpan()).Length), 8);
+    public int Size => MathUtilities.RoundUp(FixedHeaderSize + (string.IsNullOrEmpty(Name) ? 0 : MemoryMarshal.AsBytes(Name.AsSpan()).Length), 8);
 
     public int ReadFrom(ReadOnlySpan<byte> data)
     {
@@ -71,7 +74,7 @@ internal class AttributeListRecord : IDiagnosticTraceable, IByteArraySerializabl
 
     public void WriteTo(Span<byte> buffer)
     {
-        NameOffset = 0x20;
+        NameOffset = FixedHeaderSize;
         if (string.IsNullOrEmpty(Name))
         {
             NameLength = 0;

--- a/Library/DiscUtils.Ntfs/Properties/AssemblyInfo.cs
+++ b/Library/DiscUtils.Ntfs/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from
@@ -9,3 +10,4 @@
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 
 [assembly: Guid("9095333e-08e4-4c13-b556-20b5fdb9db2a")]
+[assembly: InternalsVisibleTo("LibraryTests")]

--- a/Tests/LibraryTests/Ntfs/AttributeListRecordTest.cs
+++ b/Tests/LibraryTests/Ntfs/AttributeListRecordTest.cs
@@ -1,0 +1,73 @@
+//
+// Copyright (c) 2008-2011, Kenneth Bell
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+//
+
+using System;
+using DiscUtils.Ntfs;
+
+namespace LibraryTests.Ntfs;
+
+public class AttributeListRecordTest
+{
+    private const byte FixedHeaderSize = 0x1A;
+
+    [Fact]
+    public void WriteToUsesFixedHeaderOffsetForUnnamedEntry()
+    {
+        var record = new AttributeListRecord
+        {
+            Name = string.Empty
+        };
+
+        Span<byte> buffer = stackalloc byte[64];
+        buffer.Clear();
+
+        record.WriteTo(buffer);
+
+        Assert.Equal(FixedHeaderSize, record.NameOffset);
+        Assert.Equal(FixedHeaderSize, buffer[0x07]);
+        Assert.Equal(0x20, record.RecordLength);
+        Assert.Equal(record.Size, record.RecordLength);
+    }
+
+    [Fact]
+    public void WriteToPlacesNameImmediatelyAfterFixedHeader()
+    {
+        var record = new AttributeListRecord
+        {
+            Name = "AB"
+        };
+
+        Span<byte> buffer = stackalloc byte[64];
+        buffer.Clear();
+
+        record.WriteTo(buffer);
+
+        Assert.Equal(FixedHeaderSize, record.NameOffset);
+        Assert.Equal(FixedHeaderSize, buffer[0x07]);
+        Assert.Equal((byte)'A', buffer[FixedHeaderSize]);
+        Assert.Equal((byte)0, buffer[FixedHeaderSize + 1]);
+        Assert.Equal((byte)'B', buffer[FixedHeaderSize + 2]);
+        Assert.Equal((byte)0, buffer[FixedHeaderSize + 3]);
+        Assert.Equal(0x20, record.RecordLength);
+        Assert.Equal(record.Size, record.RecordLength);
+    }
+}


### PR DESCRIPTION
## Summary

- Serialize the attribute name immediately after the 0x1A-byte fixed `$ATTRIBUTE_LIST` entry header.
- Continue aligning the overall entry length to 8 bytes.
- Add regression tests for both unnamed and named entries.

## Context

This manually ports only the functional correction from [DiscUtils/DiscUtils#310](https://github.com/DiscUtils/DiscUtils/pull/310), adapted to this fork's span-based serializer and current code style.

The fixed fields end at offset 0x1A. An unnamed entry still occupies 0x20 bytes after alignment, but 0x20 is not the name offset. Writing `NameOffset = 0x20` produces entries that Windows `ntfs.sys` rejects when an MFT record overflows into an attribute list.

## Tests

Added `AttributeListRecordTest` with:

- `WriteToUsesFixedHeaderOffsetForUnnamedEntry`
- `WriteToPlacesNameImmediatelyAfterFixedHeader`

Both tests fail against the current base implementation because it writes 0x20 rather than 0x1A; they pass with this change. Existing CI workflows will exercise the configured target frameworks.